### PR TITLE
[AB-WH-01] CRUD для правил маппинга (Admin API)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,10 @@
 # Webserver
+ADMIN_TOKEN=__CHANGEME_ADMIN_TOKEN__
 CADDY_LETSENCRYPT_EMAIL=email@for.letsencrypt
 CADDY_DOMAIN_NAME=domain.for.letsencrypt
+
+# Cache
+MEMCACHED_HOST=memcached:11211
 
 # Trace
 JAEGER_ENDPOINT=http://localhost:14268/api/traces

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -102,8 +102,8 @@ jobs:
         uses: appleboy/ssh-action@v1
         env:
           REGISTRY_HOST: ghcr.io
-          REGISTRY_USERNAME: ${{ github.repository_owner }}
-          REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           host: ${{ vars.SSH_DEPLOY_HOST }}
           username: ${{ secrets.SSH_DEPLOY_USER }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,18 +1,20 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
-	"context"
-    "os"
-    "os/signal"
-    "syscall"
+
+	"astroapi/config"
+	"astroapi/internal/database"
+	"astroapi/internal/handlers"
+	"astroapi/internal/rules"
 
 	"github.com/joho/godotenv"
-	"astroapi/internal/handlers"
-    "astroapi/internal/database"
-	"astroapi/config"
 )
 
 func main() {
@@ -21,7 +23,11 @@ func main() {
 		log.Println("Warning: .env file not found, using system environment variables")
 	}
 
-    cfg := config.Load()
+	cfg := config.Load()
+
+	if cfg.AdminToken == "" {
+		log.Println("Warning: ADMIN_TOKEN is not set, admin endpoints will reject all requests")
+	}
 
 	// Инициализируем базу данных
 	if err := database.InitDB(cfg); err != nil {
@@ -29,24 +35,27 @@ func main() {
 	}
 
 	defer func() {
-        if err := database.DB.Close(); err != nil {
-            log.Printf("Error closing database connection: %v", err)
-        }
-    }()
+		if err := database.DB.Close(); err != nil {
+			log.Printf("Error closing database connection: %v", err)
+		}
+	}()
 
+	rulesRepository := rules.NewPostgresRepository(database.DB.DB)
+	adminRulesHandler := handlers.NewAdminRulesHandler(rulesRepository)
 
 	// Настраиваем маршруты
-	http.HandleFunc("/api/v1/", handlers.HelloWorldHandler)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/", handlers.HelloWorldHandler)
+	handlers.RegisterAdminRulesRoutes(mux, cfg.AdminToken, adminRulesHandler)
 
-    // Создаем HTTP сервер с таймаутами
+	// Создаем HTTP сервер с таймаутами
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      nil,
+		Handler:      mux,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
-
 
 	// Запускаем сервер в горутине
 	go func() {
@@ -58,19 +67,19 @@ func main() {
 	}()
 
 	// Ожидаем сигнал для graceful shutdown
-    quit := make(chan os.Signal, 1)
-    signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-    <-quit
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
 
-    log.Println("Shutting down server...")
+	log.Println("Shutting down server...")
 
-    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-    defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-    if err := srv.Shutdown(ctx); err != nil {
-        log.Fatalf("Server forced to shutdown: %v", err)
-    }
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Server forced to shutdown: %v", err)
+	}
 
-    log.Println("Server exited")
+	log.Println("Server exited")
 
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,36 +3,40 @@ package config
 import (
 	"log"
 	"os"
-	"time"
 	"strconv"
+	"time"
 
 	"github.com/joho/godotenv"
 )
 
 type Config struct {
+	AdminToken string
+
+	MemcachedHost string
+
 	JaegerEndpoint    string
 	JaegerServiceName string
 
 	// Database
-    DBHost            string
-    DBPort            string
-    DBUser            string
-    DBPassword        string
-    DBName            string
-    DBSSLMode         string
+	DBHost     string
+	DBPort     string
+	DBUser     string
+	DBPassword string
+	DBName     string
+	DBSSLMode  string
 
-    // Pool settings
-    DBMaxConns        int32
-    DBMinConns        int32
-    DBMaxConnLifetime time.Duration
-    DBMaxConnIdleTime time.Duration
-    DBHealthCheckPeriod time.Duration
+	// Pool settings
+	DBMaxConns          int32
+	DBMinConns          int32
+	DBMaxConnLifetime   time.Duration
+	DBMaxConnIdleTime   time.Duration
+	DBHealthCheckPeriod time.Duration
 
-    // NATS
-    NATSHost          string
-    NATSPort          string
-    NATSClusterID     string
-    NATSClientID      string
+	// NATS
+	NATSHost      string
+	NATSPort      string
+	NATSClusterID string
+	NATSClientID  string
 }
 
 func Load() *Config {
@@ -42,15 +46,19 @@ func Load() *Config {
 	}
 
 	return &Config{
-        JaegerEndpoint:    getEnv("JAEGER_ENDPOINT", "http://localhost:14268/api/traces"),
-        JaegerServiceName: getEnv("JAEGER_SERVICE_NAME", "astro-backend"),
+		AdminToken: getEnv("ADMIN_TOKEN", ""),
 
-        DBHost:            getEnv("DB_HOST", "localhost"),
-        DBPort:            getEnv("DB_PORT", "5432"),
-        DBUser:            getEnv("DB_USER", "postgres"),
-        DBPassword:        getEnv("DB_PASSWORD", ""),
-        DBName:            getEnv("DB_NAME", "myapi_db"),
-        DBSSLMode:         getEnv("DB_SSL_MODE", "disable"),
+		MemcachedHost: getEnv("MEMCACHED_HOST", "localhost:11211"),
+
+		JaegerEndpoint:    getEnv("JAEGER_ENDPOINT", "http://localhost:14268/api/traces"),
+		JaegerServiceName: getEnv("JAEGER_SERVICE_NAME", "astro-backend"),
+
+		DBHost:     getEnv("DB_HOST", "localhost"),
+		DBPort:     getEnv("DB_PORT", "5432"),
+		DBUser:     getEnv("DB_USER", "postgres"),
+		DBPassword: getEnv("DB_PASSWORD", ""),
+		DBName:     getEnv("DB_NAME", "myapi_db"),
+		DBSSLMode:  getEnv("DB_SSL_MODE", "disable"),
 
 		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", 50),
 		DBMinConns:          getEnvAsInt32("DB_MIN_CONNS", 20),
@@ -58,10 +66,10 @@ func Load() *Config {
 		DBMaxConnIdleTime:   getEnvAsDuration("DB_MAX_CONN_IDLE_TIME", 30*time.Minute),
 		DBHealthCheckPeriod: getEnvAsDuration("DB_HEALTH_CHECK_PERIOD", time.Minute),
 
-        NATSHost:          getEnv("NATS_HOST", "localhost"),
-        NATSPort:          getEnv("NATS_PORT", "4222"),
-        NATSClusterID:     getEnv("NATS_CLUSTER_ID", "test-cluster"),
-        NATSClientID:      getEnv("NATS_CLIENT_ID", "astro-backend"),
+		NATSHost:      getEnv("NATS_HOST", "localhost"),
+		NATSPort:      getEnv("NATS_PORT", "4222"),
+		NATSClusterID: getEnv("NATS_CLUSTER_ID", "test-cluster"),
+		NATSClientID:  getEnv("NATS_CLIENT_ID", "astro-backend"),
 	}
 }
 
@@ -71,7 +79,6 @@ func getEnv(key, defaultValue string) string {
 	}
 	return defaultValue
 }
-
 
 func getEnvAsInt32(key string, defaultValue int32) int32 {
 	if value := os.Getenv(key); value != "" {

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -7,7 +7,16 @@ services:
     ports:
       - "8080:8080"
 
+  memcached:
+    ports:
+      - "11211:11211"
+
   jaeger:
     ports:
       - "16686:16686"
       - "14268:14268"
+
+  nats:
+    ports:
+      - "4222:4222"
+      - "8222:8222"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,8 +24,24 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      memcached:
+        condition: service_started
     expose:
       - 8080
+    restart: unless-stopped
+
+  memcached:
+    image: memcached:1.6.39-alpine
+    command:
+      - --conn-limit=1024
+      - --memory-limit=64
+      - --threads=2
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    expose:
+      - 11211
     restart: unless-stopped
 
   jaeger:
@@ -38,9 +54,6 @@ services:
   nats:
     image: nats:alpine
     command: ["-js", "-c", "/etc/nats/nats-server.conf"]
-    ports:
-      - "4222:4222"
-      - "8222:8222"
     volumes:
       - nats-data:/data
       - ./docker/nats/nats-server.conf:/etc/nats/nats-server.conf:ro

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,240 @@
+openapi: 3.0.3
+info:
+  title: Astro Backend API
+  version: 0.1.0
+paths:
+  /api/v1/:
+    get:
+      summary: Service health endpoint
+      responses:
+        "200":
+          description: API and database status payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Envelope"
+  /api/v1/admin/rules:
+    get:
+      summary: List astro rules
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: is_active
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        "200":
+          description: Paginated astro rules list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRulesListEnvelope"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      summary: Create an astro rule
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminRulePayload"
+      responses:
+        "201":
+          description: Astro rule created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRuleEnvelope"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+  /api/v1/admin/rules/{id}:
+    put:
+      summary: Update an astro rule
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminRulePayload"
+      responses:
+        "200":
+          description: Astro rule updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRuleEnvelope"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+    delete:
+      summary: Soft delete an astro rule by deactivating it
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Astro rule deactivated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRuleEnvelope"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  responses:
+    Unauthorized:
+      description: Missing or invalid admin token
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Envelope"
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Envelope"
+    ValidationError:
+      description: Request validation failed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Envelope"
+  schemas:
+    Envelope:
+      type: object
+      properties:
+        message:
+          type: string
+        error:
+          type: string
+        data:
+          nullable: true
+    AdminRulePayload:
+      type: object
+      required:
+        - name
+        - astro_condition
+      properties:
+        name:
+          type: string
+        astro_condition:
+          type: object
+          additionalProperties: true
+        product_tags:
+          type: array
+          items:
+            type: string
+        priority:
+          type: integer
+          minimum: 0
+          default: 100
+        is_active:
+          type: boolean
+          default: true
+    AdminRule:
+      type: object
+      required:
+        - id
+        - name
+        - astro_condition
+        - product_tags
+        - priority
+        - is_active
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        astro_condition:
+          type: object
+          additionalProperties: true
+        product_tags:
+          type: array
+          items:
+            type: string
+        priority:
+          type: integer
+          minimum: 0
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AdminRuleEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/Envelope"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/AdminRule"
+    AdminRulesListEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/Envelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/AdminRule"
+                limit:
+                  type: integer
+                offset:
+                  type: integer
+                total_count:
+                  type: integer

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -1,59 +1,58 @@
 package database
 
 import (
-    "database/sql"
-    "fmt"
-    "log"
+	"database/sql"
+	"fmt"
+	"log"
 
-    _ "github.com/lib/pq"
-    "astroapi/config"
+	"astroapi/config"
+
+	_ "github.com/lib/pq"
 )
 
 type PostgresDB struct {
-    DB *sql.DB
+	DB *sql.DB
 }
 
 var DB *PostgresDB
 
-
 func InitDB(cfg *config.Config) error {
-    // Формируем строку подключения
-    connStr := fmt.Sprintf(
-        "host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-        cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPassword, cfg.DBName, cfg.DBSSLMode,
-    )
+	// Формируем строку подключения
+	connStr := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPassword, cfg.DBName, cfg.DBSSLMode,
+	)
 
-    // Подключаемся к базе данных
-    db, err := sql.Open("postgres", connStr)
-    if err != nil {
-        return fmt.Errorf("failed to open database connection: %w", err)
-    }
+	// Подключаемся к базе данных
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("failed to open database connection: %w", err)
+	}
 
-    // Проверяем подключение
-    if err := db.Ping(); err != nil {
-        return fmt.Errorf("failed to ping database: %w", err)
-    }
+	// Проверяем подключение
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
 
-    DB = &PostgresDB{DB: db}
-    log.Printf("Successfully connected to PostgreSQL database '%s' on %s:%s",
-        cfg.DBName, cfg.DBHost, cfg.DBPort)
+	DB = &PostgresDB{DB: db}
+	log.Printf("Successfully connected to PostgreSQL database '%s' on %s:%s",
+		cfg.DBName, cfg.DBHost, cfg.DBPort)
 
-    return nil
+	return nil
 }
 
 // Close закрывает подключение к базе данных
 func (p *PostgresDB) Close() error {
-    if p.DB != nil {
-        return p.DB.Close()
-    }
-    return nil
+	if p.DB != nil {
+		return p.DB.Close()
+	}
+	return nil
 }
 
 // Ping проверяет доступность базы данных
 func (p *PostgresDB) Ping() error {
-    if p.DB == nil {
-        return fmt.Errorf("database connection is nil")
-    }
-    return p.DB.Ping()
+	if p.DB == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	return p.DB.Ping()
 }
-

--- a/internal/handlers/admin_rules.go
+++ b/internal/handlers/admin_rules.go
@@ -155,7 +155,9 @@ func (h *AdminRulesHandler) DeleteRule(w http.ResponseWriter, r *http.Request) {
 }
 
 func decodeAdminRuleRequest(r *http.Request) (adminRuleRequest, error) {
-	defer r.Body.Close()
+	defer func() {
+		_ = r.Body.Close()
+	}()
 
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()

--- a/internal/handlers/admin_rules.go
+++ b/internal/handlers/admin_rules.go
@@ -1,0 +1,251 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"astroapi/internal/rules"
+)
+
+const (
+	defaultRulesLimit   = 50
+	maxRulesLimit       = 200
+	defaultRulePriority = 100
+)
+
+type AdminRulesHandler struct {
+	repository rules.Repository
+}
+
+type adminRuleRequest struct {
+	Name           string         `json:"name"`
+	AstroCondition map[string]any `json:"astro_condition"`
+	ProductTags    []string       `json:"product_tags"`
+	Priority       *int           `json:"priority"`
+	IsActive       *bool          `json:"is_active"`
+}
+
+type adminRulesListResponse struct {
+	Items      []rules.Rule `json:"items"`
+	Limit      int          `json:"limit"`
+	Offset     int          `json:"offset"`
+	TotalCount int          `json:"total_count"`
+}
+
+func NewAdminRulesHandler(repository rules.Repository) *AdminRulesHandler {
+	return &AdminRulesHandler{repository: repository}
+}
+
+func RegisterAdminRulesRoutes(mux *http.ServeMux, adminToken string, handler *AdminRulesHandler) {
+	mux.Handle("GET /api/v1/admin/rules", AdminAuthMiddleware(adminToken, http.HandlerFunc(handler.ListRules)))
+	mux.Handle("POST /api/v1/admin/rules", AdminAuthMiddleware(adminToken, http.HandlerFunc(handler.CreateRule)))
+	mux.Handle("PUT /api/v1/admin/rules/{id}", AdminAuthMiddleware(adminToken, http.HandlerFunc(handler.UpdateRule)))
+	mux.Handle("DELETE /api/v1/admin/rules/{id}", AdminAuthMiddleware(adminToken, http.HandlerFunc(handler.DeleteRule)))
+}
+
+func (h *AdminRulesHandler) ListRules(w http.ResponseWriter, r *http.Request) {
+	listOptions, err := parseRulesListOptions(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	result, err := h.repository.List(r.Context(), listOptions)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to fetch astro rules")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Message: "Astro rules fetched successfully",
+		Data: adminRulesListResponse{
+			Items:      result.Items,
+			Limit:      listOptions.Limit,
+			Offset:     listOptions.Offset,
+			TotalCount: result.TotalCount,
+		},
+	})
+}
+
+func (h *AdminRulesHandler) CreateRule(w http.ResponseWriter, r *http.Request) {
+	payload, err := decodeAdminRuleRequest(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	input, err := payload.toRuleInput()
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	createdRule, err := h.repository.Create(r.Context(), input)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create astro rule")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, Response{
+		Message: "Astro rule created successfully",
+		Data:    createdRule,
+	})
+}
+
+func (h *AdminRulesHandler) UpdateRule(w http.ResponseWriter, r *http.Request) {
+	ruleID := strings.TrimSpace(r.PathValue("id"))
+	if ruleID == "" {
+		writeError(w, http.StatusBadRequest, "rule id is required")
+		return
+	}
+
+	payload, err := decodeAdminRuleRequest(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	input, err := payload.toRuleInput()
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	updatedRule, err := h.repository.Update(r.Context(), ruleID, input)
+	if err != nil {
+		if errors.Is(err, rules.ErrRuleNotFound) {
+			writeError(w, http.StatusNotFound, "astro rule not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to update astro rule")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Message: "Astro rule updated successfully",
+		Data:    updatedRule,
+	})
+}
+
+func (h *AdminRulesHandler) DeleteRule(w http.ResponseWriter, r *http.Request) {
+	ruleID := strings.TrimSpace(r.PathValue("id"))
+	if ruleID == "" {
+		writeError(w, http.StatusBadRequest, "rule id is required")
+		return
+	}
+
+	deactivatedRule, err := h.repository.Deactivate(r.Context(), ruleID)
+	if err != nil {
+		if errors.Is(err, rules.ErrRuleNotFound) {
+			writeError(w, http.StatusNotFound, "astro rule not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to deactivate astro rule")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Message: "Astro rule deactivated successfully",
+		Data:    deactivatedRule,
+	})
+}
+
+func decodeAdminRuleRequest(r *http.Request) (adminRuleRequest, error) {
+	defer r.Body.Close()
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	var payload adminRuleRequest
+	if err := decoder.Decode(&payload); err != nil {
+		if errors.Is(err, io.EOF) {
+			return adminRuleRequest{}, errors.New("request body is required")
+		}
+		return adminRuleRequest{}, err
+	}
+
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return adminRuleRequest{}, errors.New("request body must contain a single JSON object")
+	}
+
+	return payload, nil
+}
+
+func (r adminRuleRequest) toRuleInput() (rules.RuleInput, error) {
+	name := strings.TrimSpace(r.Name)
+	if name == "" {
+		return rules.RuleInput{}, errors.New("name is required")
+	}
+
+	if r.AstroCondition == nil {
+		return rules.RuleInput{}, errors.New("astro_condition is required")
+	}
+
+	priority := defaultRulePriority
+	if r.Priority != nil {
+		priority = *r.Priority
+	}
+	if priority < 0 {
+		return rules.RuleInput{}, errors.New("priority must be greater than or equal to 0")
+	}
+
+	productTags := r.ProductTags
+	if productTags == nil {
+		productTags = []string{}
+	}
+
+	isActive := true
+	if r.IsActive != nil {
+		isActive = *r.IsActive
+	}
+
+	return rules.RuleInput{
+		Name:           name,
+		AstroCondition: r.AstroCondition,
+		ProductTags:    productTags,
+		Priority:       priority,
+		IsActive:       isActive,
+	}, nil
+}
+
+func parseRulesListOptions(r *http.Request) (rules.ListOptions, error) {
+	query := r.URL.Query()
+
+	limit := defaultRulesLimit
+	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
+		parsedLimit, err := strconv.Atoi(rawLimit)
+		if err != nil || parsedLimit < 1 || parsedLimit > maxRulesLimit {
+			return rules.ListOptions{}, errors.New("limit must be an integer between 1 and 200")
+		}
+		limit = parsedLimit
+	}
+
+	offset := 0
+	if rawOffset := strings.TrimSpace(query.Get("offset")); rawOffset != "" {
+		parsedOffset, err := strconv.Atoi(rawOffset)
+		if err != nil || parsedOffset < 0 {
+			return rules.ListOptions{}, errors.New("offset must be an integer greater than or equal to 0")
+		}
+		offset = parsedOffset
+	}
+
+	var isActiveFilter *bool
+	if rawActive := strings.TrimSpace(query.Get("is_active")); rawActive != "" {
+		parsedActive, err := strconv.ParseBool(rawActive)
+		if err != nil {
+			return rules.ListOptions{}, errors.New("is_active must be true or false")
+		}
+		isActiveFilter = &parsedActive
+	}
+
+	return rules.ListOptions{
+		IsActive: isActiveFilter,
+		Limit:    limit,
+		Offset:   offset,
+	}, nil
+}

--- a/internal/handlers/admin_rules_test.go
+++ b/internal/handlers/admin_rules_test.go
@@ -1,0 +1,240 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"astroapi/internal/rules"
+)
+
+const testAdminToken = "test-admin-token"
+
+type fakeRulesRepository struct {
+	items map[string]rules.Rule
+}
+
+func newFakeRulesRepository(items []rules.Rule) *fakeRulesRepository {
+	repository := &fakeRulesRepository{items: make(map[string]rules.Rule, len(items))}
+	for _, item := range items {
+		repository.items[item.ID] = item
+	}
+	return repository
+}
+
+func (r *fakeRulesRepository) List(_ context.Context, options rules.ListOptions) (rules.ListResult, error) {
+	filtered := make([]rules.Rule, 0, len(r.items))
+	for _, item := range r.items {
+		if options.IsActive != nil && item.IsActive != *options.IsActive {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].Priority == filtered[j].Priority {
+			return filtered[i].ID < filtered[j].ID
+		}
+		return filtered[i].Priority < filtered[j].Priority
+	})
+
+	start := min(options.Offset, len(filtered))
+
+	end := min(start+options.Limit, len(filtered))
+
+	return rules.ListResult{
+		Items:      filtered[start:end],
+		TotalCount: len(filtered),
+	}, nil
+}
+
+func (r *fakeRulesRepository) Create(_ context.Context, input rules.RuleInput) (rules.Rule, error) {
+	now := time.Now().UTC()
+	createdRule := rules.Rule{
+		ID:             "created-rule-id",
+		Name:           input.Name,
+		AstroCondition: input.AstroCondition,
+		ProductTags:    input.ProductTags,
+		Priority:       input.Priority,
+		IsActive:       input.IsActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	r.items[createdRule.ID] = createdRule
+	return createdRule, nil
+}
+
+func (r *fakeRulesRepository) Update(_ context.Context, id string, input rules.RuleInput) (rules.Rule, error) {
+	currentRule, ok := r.items[id]
+	if !ok {
+		return rules.Rule{}, rules.ErrRuleNotFound
+	}
+
+	currentRule.Name = input.Name
+	currentRule.AstroCondition = input.AstroCondition
+	currentRule.ProductTags = input.ProductTags
+	currentRule.Priority = input.Priority
+	currentRule.IsActive = input.IsActive
+	currentRule.UpdatedAt = time.Now().UTC()
+	r.items[id] = currentRule
+
+	return currentRule, nil
+}
+
+func (r *fakeRulesRepository) Deactivate(_ context.Context, id string) (rules.Rule, error) {
+	currentRule, ok := r.items[id]
+	if !ok {
+		return rules.Rule{}, rules.ErrRuleNotFound
+	}
+
+	currentRule.IsActive = false
+	currentRule.UpdatedAt = time.Now().UTC()
+	r.items[id] = currentRule
+
+	return currentRule, nil
+}
+
+func newAdminRulesTestMux(repository rules.Repository) *http.ServeMux {
+	mux := http.NewServeMux()
+	RegisterAdminRulesRoutes(mux, testAdminToken, NewAdminRulesHandler(repository))
+	return mux
+}
+
+func TestAdminRulesRequireToken(t *testing.T) {
+	t.Parallel()
+
+	mux := newAdminRulesTestMux(newFakeRulesRepository(nil))
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/rules", nil)
+	response := httptest.NewRecorder()
+
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, response.Code)
+	}
+}
+
+func TestCreateRuleRejectsNegativePriority(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"name":"Retrograde rule","astro_condition":{"planet":"mars"},"product_tags":["energy"],"priority":-1}`)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/admin/rules", bytes.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	mux := newAdminRulesTestMux(newFakeRulesRepository(nil))
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected status %d, got %d", http.StatusUnprocessableEntity, response.Code)
+	}
+}
+
+func TestDeleteRuleSoftDeletesRecord(t *testing.T) {
+	t.Parallel()
+
+	ruleID := "11111111-1111-1111-1111-111111111111"
+	repository := newFakeRulesRepository([]rules.Rule{
+		{
+			ID:             ruleID,
+			Name:           "Seasonal rule",
+			AstroCondition: map[string]any{"sign": "aries"},
+			ProductTags:    []string{"spring"},
+			Priority:       10,
+			IsActive:       true,
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+		},
+	})
+
+	request := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/rules/"+ruleID, nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	mux := newAdminRulesTestMux(repository)
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	storedRule, exists := repository.items[ruleID]
+	if !exists {
+		t.Fatal("expected soft-deleted rule to stay in repository")
+	}
+
+	if storedRule.IsActive {
+		t.Fatal("expected soft-deleted rule to be deactivated")
+	}
+}
+
+func TestListRulesFiltersByActiveFlag(t *testing.T) {
+	t.Parallel()
+
+	repository := newFakeRulesRepository([]rules.Rule{
+		{
+			ID:             "11111111-1111-1111-1111-111111111111",
+			Name:           "Active rule",
+			AstroCondition: map[string]any{"sign": "aries"},
+			ProductTags:    []string{"spring"},
+			Priority:       1,
+			IsActive:       true,
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+		},
+		{
+			ID:             "22222222-2222-2222-2222-222222222222",
+			Name:           "Inactive rule",
+			AstroCondition: map[string]any{"sign": "taurus"},
+			ProductTags:    []string{"earth"},
+			Priority:       2,
+			IsActive:       false,
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+		},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/rules?is_active=true&limit=50&offset=0", nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	mux := newAdminRulesTestMux(repository)
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	var envelope Response
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	payload, ok := envelope.Data.(map[string]any)
+	if !ok {
+		t.Fatal("expected response data to be a map")
+	}
+
+	items, ok := payload["items"].([]any)
+	if !ok {
+		t.Fatal("expected response data.items to be a list")
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("expected one active rule, got %d", len(items))
+	}
+
+	item, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatal("expected first rule item to be an object")
+	}
+
+	if item["is_active"] != true {
+		t.Fatal("expected filtered item to be active")
+	}
+}

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Response struct {
-    Message string      `json:"message"`
-    Data    interface{} `json:"data,omitempty"`
-    Error   string      `json:"error,omitempty"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+	Error   string `json:"error,omitempty"`
 }
 
 // HelloWorldHandler обрабатывает GET запрос на /api/v1/
@@ -21,17 +21,17 @@ func HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-    // Проверяем подключение к БД
-    var dbStatus string
-    if database.DB != nil {
-        if err := database.DB.Ping(); err == nil {
-            dbStatus = "connected"
-        } else {
-            dbStatus = "disconnected"
-        }
-    } else {
-        dbStatus = "not initialized"
-    }
+	// Проверяем подключение к БД
+	var dbStatus string
+	if database.DB != nil {
+		if err := database.DB.Ping(); err == nil {
+			dbStatus = "connected"
+		} else {
+			dbStatus = "disconnected"
+		}
+	} else {
+		dbStatus = "not initialized"
+	}
 
 	// Устанавливаем заголовок Content-Type
 	w.Header().Set("Content-Type", "application/json")
@@ -39,9 +39,9 @@ func HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 	// Создаем ответ
 	response := Response{
 		Message: "Hello world",
-		Data: map[string]interface{}{
-            "database_status": dbStatus,
-        },
+		Data: map[string]any{
+			"database_status": dbStatus,
+		},
 	}
 
 	// Кодируем в JSON и отправляем

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -1,1 +1,20 @@
 package handlers
+
+import (
+	"net/http"
+	"strings"
+)
+
+func AdminAuthMiddleware(adminToken string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+		expectedHeader := "Bearer " + adminToken
+
+		if adminToken == "" || authHeader == "" || authHeader != expectedHeader {
+			writeError(w, http.StatusUnauthorized, "admin authorization token is missing or invalid")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func writeError(w http.ResponseWriter, statusCode int, message string) {
+	writeJSON(w, statusCode, Response{Error: message})
+}

--- a/internal/rules/postgres_repository.go
+++ b/internal/rules/postgres_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -46,18 +47,17 @@ func (r *PostgresRepository) List(ctx context.Context, options ListOptions) (Lis
 	offsetArgIndex := len(queryArgs) + 2
 	queryArgs = append(queryArgs, options.Limit, options.Offset)
 
-	selectQuery := fmt.Sprintf(`
-		SELECT id, name, astro_condition, product_tags, priority, is_active, created_at, updated_at
-		FROM astro_rules%s
-		ORDER BY priority ASC, created_at DESC
-		LIMIT $%d OFFSET $%d
-	`, whereClause, limitArgIndex, offsetArgIndex)
+	selectQuery := buildListQuery(whereClause, limitArgIndex, offsetArgIndex)
 
 	rows, err := r.db.QueryContext(ctx, selectQuery, queryArgs...)
 	if err != nil {
 		return ListResult{}, fmt.Errorf("list astro rules: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Printf("failed to close astro rules rows: %v", closeErr)
+		}
+	}()
 
 	ruleItems := make([]Rule, 0)
 	for rows.Next() {
@@ -220,4 +220,20 @@ func normalizeQuery(conditions []string) string {
 		return ""
 	}
 	return " WHERE " + strings.Join(conditions, " AND ")
+}
+
+func buildListQuery(whereClause string, limitArgIndex int, offsetArgIndex int) string {
+	queryBuilder := strings.Builder{}
+	queryBuilder.WriteString(`
+		SELECT id, name, astro_condition, product_tags, priority, is_active, created_at, updated_at
+		FROM astro_rules`)
+	queryBuilder.WriteString(whereClause)
+	queryBuilder.WriteString(`
+		ORDER BY priority ASC, created_at DESC
+		LIMIT $`)
+	queryBuilder.WriteString(fmt.Sprintf("%d", limitArgIndex))
+	queryBuilder.WriteString(` OFFSET $`)
+	queryBuilder.WriteString(fmt.Sprintf("%d", offsetArgIndex))
+
+	return queryBuilder.String()
 }

--- a/internal/rules/postgres_repository.go
+++ b/internal/rules/postgres_repository.go
@@ -1,0 +1,223 @@
+package rules
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrRuleNotFound = errors.New("astro rule not found")
+)
+
+type PostgresRepository struct {
+	db *sql.DB
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) List(ctx context.Context, options ListOptions) (ListResult, error) {
+	conditions := make([]string, 0, 1)
+	queryArgs := make([]any, 0, 3)
+
+	if options.IsActive != nil {
+		queryArgs = append(queryArgs, *options.IsActive)
+		conditions = append(conditions, "is_active = $1")
+	}
+
+	whereClause := normalizeQuery(conditions)
+
+	var totalCount int
+	countQuery := "SELECT COUNT(*) FROM astro_rules" + whereClause
+	if err := r.db.QueryRowContext(ctx, countQuery, queryArgs...).Scan(&totalCount); err != nil {
+		return ListResult{}, fmt.Errorf("count astro rules: %w", err)
+	}
+
+	limitArgIndex := len(queryArgs) + 1
+	offsetArgIndex := len(queryArgs) + 2
+	queryArgs = append(queryArgs, options.Limit, options.Offset)
+
+	selectQuery := fmt.Sprintf(`
+		SELECT id, name, astro_condition, product_tags, priority, is_active, created_at, updated_at
+		FROM astro_rules%s
+		ORDER BY priority ASC, created_at DESC
+		LIMIT $%d OFFSET $%d
+	`, whereClause, limitArgIndex, offsetArgIndex)
+
+	rows, err := r.db.QueryContext(ctx, selectQuery, queryArgs...)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("list astro rules: %w", err)
+	}
+	defer rows.Close()
+
+	ruleItems := make([]Rule, 0)
+	for rows.Next() {
+		ruleItem, scanErr := scanRule(rows)
+		if scanErr != nil {
+			return ListResult{}, scanErr
+		}
+		ruleItems = append(ruleItems, ruleItem)
+	}
+	if err := rows.Err(); err != nil {
+		return ListResult{}, fmt.Errorf("iterate astro rules: %w", err)
+	}
+
+	return ListResult{
+		Items:      ruleItems,
+		TotalCount: totalCount,
+	}, nil
+}
+
+func (r *PostgresRepository) Create(ctx context.Context, input RuleInput) (Rule, error) {
+	conditionJSON, tagsJSON, err := marshalRulePayload(input)
+	if err != nil {
+		return Rule{}, err
+	}
+
+	row := r.db.QueryRowContext(
+		ctx,
+		`
+			INSERT INTO astro_rules (name, astro_condition, product_tags, priority, is_active)
+			VALUES ($1, $2::jsonb, $3::jsonb, $4, $5)
+			RETURNING id, name, astro_condition, product_tags, priority, is_active, created_at, updated_at
+		`,
+		input.Name,
+		conditionJSON,
+		tagsJSON,
+		input.Priority,
+		input.IsActive,
+	)
+
+	ruleItem, scanErr := scanRule(row)
+	if scanErr != nil {
+		return Rule{}, scanErr
+	}
+
+	return ruleItem, nil
+}
+
+func (r *PostgresRepository) Update(ctx context.Context, id string, input RuleInput) (Rule, error) {
+	conditionJSON, tagsJSON, err := marshalRulePayload(input)
+	if err != nil {
+		return Rule{}, err
+	}
+
+	row := r.db.QueryRowContext(
+		ctx,
+		`
+			UPDATE astro_rules
+			SET name = $2,
+			    astro_condition = $3::jsonb,
+			    product_tags = $4::jsonb,
+			    priority = $5,
+			    is_active = $6,
+			    updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1
+			RETURNING id, name, astro_condition, product_tags, priority, is_active, created_at, updated_at
+		`,
+		id,
+		input.Name,
+		conditionJSON,
+		tagsJSON,
+		input.Priority,
+		input.IsActive,
+	)
+
+	ruleItem, scanErr := scanRule(row)
+	if scanErr != nil {
+		return Rule{}, scanErr
+	}
+
+	return ruleItem, nil
+}
+
+func (r *PostgresRepository) Deactivate(ctx context.Context, id string) (Rule, error) {
+	row := r.db.QueryRowContext(
+		ctx,
+		`
+			UPDATE astro_rules
+			SET is_active = FALSE,
+			    updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1
+			RETURNING id, name, astro_condition, product_tags, priority, is_active, created_at, updated_at
+		`,
+		id,
+	)
+
+	ruleItem, scanErr := scanRule(row)
+	if scanErr != nil {
+		return Rule{}, scanErr
+	}
+
+	return ruleItem, nil
+}
+
+func marshalRulePayload(input RuleInput) ([]byte, []byte, error) {
+	conditionJSON, err := json.Marshal(input.AstroCondition)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal astro condition: %w", err)
+	}
+
+	tagsJSON, err := json.Marshal(input.ProductTags)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal product tags: %w", err)
+	}
+
+	return conditionJSON, tagsJSON, nil
+}
+
+func scanRule(scanner rowScanner) (Rule, error) {
+	ruleItem := Rule{}
+	var conditionJSON []byte
+	var tagsJSON []byte
+
+	if err := scanner.Scan(
+		&ruleItem.ID,
+		&ruleItem.Name,
+		&conditionJSON,
+		&tagsJSON,
+		&ruleItem.Priority,
+		&ruleItem.IsActive,
+		&ruleItem.CreatedAt,
+		&ruleItem.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Rule{}, ErrRuleNotFound
+		}
+		return Rule{}, fmt.Errorf("scan astro rule: %w", err)
+	}
+
+	if err := json.Unmarshal(conditionJSON, &ruleItem.AstroCondition); err != nil {
+		return Rule{}, fmt.Errorf("decode astro condition: %w", err)
+	}
+
+	if len(ruleItem.AstroCondition) == 0 {
+		ruleItem.AstroCondition = map[string]any{}
+	}
+
+	if err := json.Unmarshal(tagsJSON, &ruleItem.ProductTags); err != nil {
+		return Rule{}, fmt.Errorf("decode product tags: %w", err)
+	}
+
+	if ruleItem.ProductTags == nil {
+		ruleItem.ProductTags = []string{}
+	}
+
+	return ruleItem, nil
+}
+
+func normalizeQuery(conditions []string) string {
+	if len(conditions) == 0 {
+		return ""
+	}
+	return " WHERE " + strings.Join(conditions, " AND ")
+}

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -1,0 +1,43 @@
+package rules
+
+import (
+	"context"
+	"time"
+)
+
+type Rule struct {
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	AstroCondition map[string]any `json:"astro_condition"`
+	ProductTags    []string       `json:"product_tags"`
+	Priority       int            `json:"priority"`
+	IsActive       bool           `json:"is_active"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+}
+
+type RuleInput struct {
+	Name           string
+	AstroCondition map[string]any
+	ProductTags    []string
+	Priority       int
+	IsActive       bool
+}
+
+type ListOptions struct {
+	IsActive *bool
+	Limit    int
+	Offset   int
+}
+
+type ListResult struct {
+	Items      []Rule
+	TotalCount int
+}
+
+type Repository interface {
+	List(ctx context.Context, options ListOptions) (ListResult, error)
+	Create(ctx context.Context, input RuleInput) (Rule, error)
+	Update(ctx context.Context, id string, input RuleInput) (Rule, error)
+	Deactivate(ctx context.Context, id string) (Rule, error)
+}


### PR DESCRIPTION
Реализованы эндпоинты:
GET /api/v1/admin/rules — список всех правил (фильтр по is_active, пагинация)
POST /api/v1/admin/rules — создать правило
PUT /api/v1/admin/rules/{id} — обновить правило
DELETE /api/v1/admin/rules/{id} — деактивировать (soft delete: is_active = false)
Все admin-эндпоинты защищены middleware: проверка Authorization: Bearer <ADMIN_TOKEN>

Вернул memcached.
Поправил токен для доступа к ресурсам и вернул порты 'nats'  в override файл. 