### PR TITLE
feat(api-03): implement feedback endpoint with strict errors and context

### DIFF
--- a/internal/handlers/feedback.go
+++ b/internal/handlers/feedback.go
@@ -2,8 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	"astroapi/internal/models"
@@ -26,68 +26,54 @@ type feedbackRequest struct {
 	Comment   string `json:"comment"`
 }
 
-// CreateFeedback эндпоинт POST /api/v1/astro/feedback
 func (h *FeedbackHandler) CreateFeedback(w http.ResponseWriter, r *http.Request) {
-	// 1. Декодируем входящий JSON
 	var req feedbackRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"error": "неверный формат JSON"}`, http.StatusBadRequest)
 		return
 	}
 
-	// ВАЛИДАЦИЯ (согласно DoD)
 	if req.RequestID == "" {
 		http.Error(w, `{"error": "request_id обязателен"}`, http.StatusBadRequest)
 		return
 	}
 
-	// Проверка: rating строго 1–5 -> иначе 422 Unprocessable Entity
 	if req.Rating < 1 || req.Rating > 5 {
 		http.Error(w, `{"error": "rating должен быть от 1 до 5"}`, http.StatusUnprocessableEntity)
 		return
 	}
 
-	// Проверка длины комментария (опционально, но полезно для защиты БД)
 	if len(req.Comment) > 500 {
 		http.Error(w, `{"error": "comment не должен превышать 500 символов"}`, http.StatusUnprocessableEntity)
 		return
 	}
 
-	// Формируем модель для БД
 	feedback := &models.Feedback{
-		ID:        uuid.New().String(), // Генерируем уникальный ID для самого отзыва
+		ID:        uuid.New().String(),
 		RequestID: req.RequestID,
 		Rating:    req.Rating,
 		Comment:   req.Comment,
 		CreatedAt: time.Now(),
 	}
 
-	// Пытаемся сохранить в базу через наш репозиторий
-	err := h.repo.Create(feedback)
+	err := h.repo.Create(r.Context(), feedback)
 	if err != nil {
-		errStr := err.Error()
-
-		// Обрабатываем ошибку дубликата -> 409 Conflict
-		if strings.Contains(errStr, "уже существует") {
-			http.Error(w, `{"error": "`+errStr+`"}`, http.StatusConflict)
+		// Эталонная обработка ошибок (без парсинга строк)
+		if errors.Is(err, models.ErrFeedbackExists) {
+			http.Error(w, `{"error": "отзыв для этого request_id уже существует"}`, http.StatusConflict)
 			return
 		}
 
-		// Обрабатываем ошибку несуществующего request_id -> 404 Not Found
-		if strings.Contains(errStr, "не найден") {
-			http.Error(w, `{"error": "`+errStr+`"}`, http.StatusNotFound)
+		if errors.Is(err, models.ErrRequestNotFound) {
+			http.Error(w, `{"error": "указанный request_id не найден"}`, http.StatusNotFound)
 			return
 		}
 
-		// Если упало что-то другое (например, отвалилась БД) -> 500
 		http.Error(w, `{"error": "внутренняя ошибка сервера"}`, http.StatusInternalServerError)
 		return
 	}
 
-	// Возвращаем 201 Created
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	if _, err := w.Write([]byte(`{"status": "success", "message": "Отзыв успешно сохранен"}`)); err != nil {
-		return
-	}
+	_, _ = w.Write([]byte(`{"status": "success", "message": "Отзыв успешно сохранен"}`))
 }

--- a/internal/handlers/feedback_test.go
+++ b/internal/handlers/feedback_test.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"bytes"
-	"errors"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,13 +10,14 @@ import (
 	"astroapi/internal/models"
 )
 
+// Обновляем мок: добавляем context.Context
 type mockFeedbackRepo struct {
-	mockCreate func(f *models.Feedback) error
+	mockCreate func(ctx context.Context, f *models.Feedback) error
 }
 
-func (m *mockFeedbackRepo) Create(f *models.Feedback) error {
+func (m *mockFeedbackRepo) Create(ctx context.Context, f *models.Feedback) error {
 	if m.mockCreate != nil {
-		return m.mockCreate(f)
+		return m.mockCreate(ctx, f)
 	}
 	return nil
 }
@@ -25,34 +26,36 @@ func TestCreateFeedback(t *testing.T) {
 	tests := []struct {
 		name           string
 		requestBody    string
-		mockSetup      func(f *models.Feedback) error
+		mockSetup      func(ctx context.Context, f *models.Feedback) error
 		expectedStatus int
 	}{
 		{
 			name:           "Успешное сохранение (201 Created)",
 			requestBody:    `{"request_id": "550e8400-e29b-41d4-a716-446655440000", "rating": 5, "comment": "Отлично!"}`,
-			mockSetup:      func(f *models.Feedback) error { return nil },
+			mockSetup:      func(ctx context.Context, f *models.Feedback) error { return nil },
 			expectedStatus: http.StatusCreated,
 		},
 		{
 			name:           "Ошибка валидации: rating=6 (422 Unprocessable Entity)", // DoD: Тест: rating=6 -> 422
 			requestBody:    `{"request_id": "550e8400-e29b-41d4-a716-446655440000", "rating": 6}`,
-			mockSetup:      func(f *models.Feedback) error { return nil },
+			mockSetup:      func(ctx context.Context, f *models.Feedback) error { return nil },
 			expectedStatus: http.StatusUnprocessableEntity,
 		},
 		{
 			name:        "Ошибка: несуществующий request_id (404 Not Found)", // DoD: Тест: несуществующий request_id -> 404
 			requestBody: `{"request_id": "fake-uuid", "rating": 4}`,
-			mockSetup: func(f *models.Feedback) error {
-				return errors.New("указанный request_id не найден")
+			mockSetup: func(ctx context.Context, f *models.Feedback) error {
+				// Используем нашу строгую ошибку из моделей
+				return models.ErrRequestNotFound
 			},
 			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name:        "Ошибка: дублирование отзыва (409 Conflict)", // DoD: Дублирование feedback -> 409 Conflict
 			requestBody: `{"request_id": "550e8400-e29b-41d4-a716-446655440000", "rating": 4}`,
-			mockSetup: func(f *models.Feedback) error {
-				return errors.New("отзыв для этого request_id уже существует")
+			mockSetup: func(ctx context.Context, f *models.Feedback) error {
+				// Используем нашу строгую ошибку из моделей
+				return models.ErrFeedbackExists
 			},
 			expectedStatus: http.StatusConflict,
 		},
@@ -64,14 +67,11 @@ func TestCreateFeedback(t *testing.T) {
 			repo := &mockFeedbackRepo{mockCreate: tt.mockSetup}
 			handler := NewFeedbackHandler(repo)
 
-			// Создаем HTTP-запрос
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/astro/feedback", bytes.NewBufferString(tt.requestBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			// Создаем объект для записи ответа
 			rr := httptest.NewRecorder()
 
-			// Вызываем хендлер напрямую
 			handler.CreateFeedback(rr, req)
 
 			// Проверяем, совпал ли полученный статус с ожидаемым по ТЗ

--- a/internal/models/feedback.go
+++ b/internal/models/feedback.go
@@ -1,6 +1,14 @@
 package models
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrRequestNotFound = errors.New("указанный request_id не найден")
+	ErrFeedbackExists  = errors.New("отзыв для этого request_id уже существует")
+)
 
 type Feedback struct {
 	ID        string    `json:"id"`

--- a/internal/repositories/feedback_postgres.go
+++ b/internal/repositories/feedback_postgres.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FeedbackRepository interface {
-	Create(f *models.Feedback) error
+	Create(ctx context.Context, f *models.Feedback) error
 }
 
 type feedbackPG struct {
@@ -21,12 +21,12 @@ func NewFeedbackRepository(db *sql.DB) FeedbackRepository {
 	return &feedbackPG{db: db}
 }
 
-func (r *feedbackPG) Create(f *models.Feedback) error {
+func (r *feedbackPG) Create(ctx context.Context, f *models.Feedback) error {
 	query := `
 		INSERT INTO feedback (id, request_id, rating, comment, created_at)
 		VALUES ($1, $2, $3, $4, $5)
 	`
-	_, err := r.db.ExecContext(context.Background(), query, f.ID, f.RequestID, f.Rating, f.Comment, f.CreatedAt)
+	_, err := r.db.ExecContext(ctx, query, f.ID, f.RequestID, f.Rating, f.Comment, f.CreatedAt)
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "unique constraint") || strings.Contains(errStr, "23505") {


### PR DESCRIPTION
Что сделано:
Реализован эндпоинт `POST /api/v1/astro/feedback` согласно ТЗ (API-03).
- Добавлена модель `Feedback` и строгие Sentinel Errors (`ErrRequestNotFound`, `ErrFeedbackExists`).
- Реализован слой репозитория `FeedbackRepository` с поддержкой `context.Context` и обработкой ошибок БД (PostgreSQL constraints).
- Реализован HTTP-хендлер с валидацией входящих данных.
- Подключены зависимости в `cmd/main.go`.

  Definition of Done (DoD):
- [x] Тест: `rating=6` → `422 Unprocessable Entity`
- [x] Тест: несуществующий `request_id` → `404 Not Found`
- [x] Feedback сохраняется в БД (статус `201 Created`)
- [x] Дублирование feedback для одного `request_id` → `409 Conflict`
- [x] Отсутствуют конфликты с веткой `dev`
- [x] Линтер и тесты проходят успешно