### PR TITLE
[AB-WH-03] Эндпоинт логов генерации

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 
 	"astroapi/config"
 	"astroapi/internal/admin"
+	"astroapi/internal/adminlogs"
 	"astroapi/internal/alisa"
 	"astroapi/internal/database"
 	"astroapi/internal/handlers"
@@ -116,6 +117,7 @@ func run() error {
 	// 3. Repositories
 	userRepo := user.NewPostgresRepository(db.DB, encryptionKey)
 	requestsRepo := requests.NewPostgresRepository(db.DB)
+	adminLogsRepo := adminlogs.NewPostgresRepository(db.DB)
 	rulesRepo := rules.NewPostgresRepository(db.DB, zapLogger)
 	productsRepo := products.NewPostgresRepository(db.DB)
 	adminRepo := admin.NewPostgresRepository(db.DB)
@@ -180,6 +182,7 @@ func run() error {
 	recommendHandler := handlers.NewRecommendHandler(publisher, userRepo, rulesRepo, aiClient, requestsRepo, zapLogger)
 	adminRulesHandler := handlers.NewAdminRulesHandler(rulesRepo)
 	adminProductsHandler := handlers.NewAdminProductsHandler(productsRepo, nil)
+	adminLogsHandler := handlers.NewAdminLogsHandler(adminLogsRepo)
 	authHandler := handlers.NewAuthHandler(adminRepo, cfg.AdminToken)
 
 	dlqreader := natsinfra.NewDLQReader(jsAdapter, zapLogger)
@@ -200,6 +203,7 @@ func run() error {
 	r.Post("/api/v1/admin/catalog/import", handlers.NewImportHandler(db))
 	handlers.RegisterAdminRulesRoutes(r, cfg.AdminToken, adminRulesHandler)
 	handlers.RegisterAdminProductsRoutes(r, cfg.AdminToken, adminProductsHandler)
+	handlers.RegisterAdminLogsRoutes(r, cfg.AdminToken, adminLogsHandler)
 
 	r.Group(func(r chi.Router) {
 		r.Use(handlers.AdminAuthMiddleware(cfg.AdminToken))

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -492,22 +492,17 @@ paths:
           in: query
           schema:
             type: string
-            enum: [accepted, processing, completed, failed]
-        - name: date_from
+            enum: [pending, processing, completed, failed]
+        - name: from
           in: query
           schema:
             type: string
             format: date-time
-        - name: date_to
+        - name: to
           in: query
           schema:
             type: string
             format: date-time
-        - name: page
-          in: query
-          schema:
-            type: integer
-            default: 1
         - name: limit
           in: query
           schema:
@@ -521,6 +516,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AdminLogsListEnvelope"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
 
@@ -961,7 +958,7 @@ components:
           type: string
         status:
           type: string
-          enum: [accepted, processing, completed, failed]
+          enum: [pending, processing, completed, failed]
         attempt_count:
           type: integer
         error_reason:
@@ -976,6 +973,35 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    AdminLogEntry:
+      type: object
+      required:
+        - request_id
+        - user_id
+        - status
+        - error_message
+        - created_at
+        - completed_at
+      properties:
+        request_id:
+          type: string
+          format: uuid
+        user_id:
+          type: string
+        status:
+          type: string
+          enum: [pending, processing, completed, failed]
+        error_message:
+          type: string
+          maxLength: 500
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
 
     RequestLogEnvelope:
       allOf:
@@ -996,10 +1022,6 @@ components:
                 items:
                   type: array
                   items:
-                    $ref: "#/components/schemas/RequestLog"
-                total:
-                  type: integer
-                page:
-                  type: integer
-                limit:
+                    $ref: "#/components/schemas/AdminLogEntry"
+                total_count:
                   type: integer

--- a/internal/adminlogs/logs.go
+++ b/internal/adminlogs/logs.go
@@ -1,0 +1,65 @@
+// Package adminlogs описывает чтение административного журнала генераций.
+package adminlogs
+
+import (
+	"context"
+	"time"
+
+	"astroapi/internal/requests"
+)
+
+const maxErrorMessageLength = 500
+
+var allowedStatuses = map[string]struct{}{
+	requests.StatusPending:    {},
+	requests.StatusProcessing: {},
+	requests.StatusCompleted:  {},
+	requests.StatusFailed:     {},
+}
+
+// LogEntry описывает одну запись журнала генераций для административного API.
+type LogEntry struct {
+	RequestID    string     `json:"request_id"`
+	UserID       string     `json:"user_id"`
+	Status       string     `json:"status"`
+	ErrorMessage string     `json:"error_message"`
+	CreatedAt    time.Time  `json:"created_at"`
+	CompletedAt  *time.Time `json:"completed_at"`
+}
+
+// ListOptions задает фильтры и лимит выборки журнала.
+type ListOptions struct {
+	Status string
+	From   *time.Time
+	To     *time.Time
+	Limit  int
+}
+
+// ListResult содержит записи журнала и общее количество по фильтрам.
+type ListResult struct {
+	Items      []LogEntry
+	TotalCount int
+}
+
+// Repository описывает чтение журнала генераций из хранилища.
+type Repository interface {
+	List(ctx context.Context, options ListOptions) (ListResult, error)
+}
+
+// IsValidStatus проверяет, входит ли статус в разрешенный набор.
+// На вход принимает строковый статус, на выход возвращает true для допустимого значения.
+func IsValidStatus(status string) bool {
+	_, ok := allowedStatuses[status]
+	return ok
+}
+
+// TruncateErrorMessage обрезает текст ошибки до лимита административного ответа.
+// На вход принимает исходную ошибку, на выход возвращает строку длиной не больше 500 символов.
+func TruncateErrorMessage(message string) string {
+	runes := []rune(message)
+	if len(runes) <= maxErrorMessageLength {
+		return message
+	}
+
+	return string(runes[:maxErrorMessageLength])
+}

--- a/internal/adminlogs/postgres_repository.go
+++ b/internal/adminlogs/postgres_repository.go
@@ -1,0 +1,111 @@
+package adminlogs
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// PostgresRepository читает административный журнал генераций из PostgreSQL.
+type PostgresRepository struct {
+	db *sql.DB
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// NewPostgresRepository создает PostgreSQL-репозиторий административного журнала.
+// На вход принимает соединение с БД, на выход возвращает готовый репозиторий.
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// List возвращает записи requests_log по фильтрам и общий счетчик.
+// На вход принимает контекст и параметры фильтрации, на выход возвращает список записей или ошибку.
+func (r *PostgresRepository) List(ctx context.Context, options ListOptions) (ListResult, error) {
+	const countQuery = `
+		SELECT COUNT(*)
+		FROM requests_log
+		WHERE ($1 = '' OR status = $1)
+		  AND ($2::timestamptz IS NULL OR created_at >= $2::timestamptz)
+		  AND ($3::timestamptz IS NULL OR created_at <= $3::timestamptz)
+	`
+
+	fromArg := timeArg(options.From)
+	toArg := timeArg(options.To)
+
+	var totalCount int
+	if err := r.db.QueryRowContext(ctx, countQuery, options.Status, fromArg, toArg).Scan(&totalCount); err != nil {
+		return ListResult{}, fmt.Errorf("count requests_log: %w", err)
+	}
+
+	const listQuery = `
+		SELECT request_id, user_id, status, COALESCE(error_reason, ''), created_at, completed_at
+		FROM requests_log
+		WHERE ($1 = '' OR status = $1)
+		  AND ($2::timestamptz IS NULL OR created_at >= $2::timestamptz)
+		  AND ($3::timestamptz IS NULL OR created_at <= $3::timestamptz)
+		ORDER BY created_at DESC
+		LIMIT $4
+	`
+
+	rows, err := r.db.QueryContext(ctx, listQuery, options.Status, fromArg, toArg, options.Limit)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("list requests_log: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	items := make([]LogEntry, 0)
+	for rows.Next() {
+		item, scanErr := scanLogEntry(rows)
+		if scanErr != nil {
+			return ListResult{}, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return ListResult{}, fmt.Errorf("iterate requests_log: %w", err)
+	}
+
+	return ListResult{Items: items, TotalCount: totalCount}, nil
+}
+
+// timeArg преобразует указатель времени в значение для SQL-параметра.
+// На вход принимает указатель на время, на выход возвращает время или nil.
+func timeArg(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
+}
+
+// scanLogEntry сканирует строку БД в LogEntry.
+// На вход принимает rowScanner, на выход возвращает запись журнала или ошибку.
+func scanLogEntry(scanner rowScanner) (LogEntry, error) {
+	var (
+		item        LogEntry
+		completedAt sql.NullTime
+	)
+
+	if err := scanner.Scan(
+		&item.RequestID,
+		&item.UserID,
+		&item.Status,
+		&item.ErrorMessage,
+		&item.CreatedAt,
+		&completedAt,
+	); err != nil {
+		return LogEntry{}, fmt.Errorf("scan requests_log: %w", err)
+	}
+	if completedAt.Valid {
+		item.CompletedAt = &completedAt.Time
+	}
+	item.ErrorMessage = TruncateErrorMessage(item.ErrorMessage)
+
+	return item, nil
+}

--- a/internal/adminlogs/postgres_repository_test.go
+++ b/internal/adminlogs/postgres_repository_test.go
@@ -1,0 +1,92 @@
+package adminlogs_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"astroapi/internal/adminlogs"
+	"astroapi/internal/requests"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+// newAdminLogsRepoTest создает sqlmock-репозиторий для тестов.
+// На вход принимает тест, на выход возвращает репозиторий, БД и mock.
+func newAdminLogsRepoTest(t *testing.T) (*adminlogs.PostgresRepository, *sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+
+	return adminlogs.NewPostgresRepository(db), db, mock
+}
+
+// TestListFiltersByFailedStatus проверяет выборку только failed-записей по статусу.
+// На вход принимает тестовый контекст, на выход проверяет результат репозитория.
+func TestListFiltersByFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	repository, db, mock := newAdminLogsRepoTest(t)
+	defer db.Close()
+
+	createdAt := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	completedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM requests_log`).
+		WithArgs(requests.StatusFailed, nil, nil).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	rows := sqlmock.NewRows([]string{
+		"request_id", "user_id", "status", "error_reason", "created_at", "completed_at",
+	}).AddRow("req-1", "user-1", requests.StatusFailed, "failed reason", createdAt, completedAt)
+
+	mock.ExpectQuery(`SELECT request_id, user_id, status`).
+		WithArgs(requests.StatusFailed, nil, nil, 50).
+		WillReturnRows(rows)
+
+	result, err := repository.List(context.Background(), adminlogs.ListOptions{
+		Status: requests.StatusFailed,
+		Limit:  50,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalCount)
+	require.Len(t, result.Items, 1)
+	require.Equal(t, requests.StatusFailed, result.Items[0].Status)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestListTruncatesErrorMessage проверяет обрезку error_message до 500 символов.
+// На вход принимает тестовый контекст, на выход проверяет длину ошибки в результате.
+func TestListTruncatesErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	repository, db, mock := newAdminLogsRepoTest(t)
+	defer db.Close()
+
+	createdAt := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	longError := strings.Repeat("я", 501)
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM requests_log`).
+		WithArgs("", nil, nil).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	rows := sqlmock.NewRows([]string{
+		"request_id", "user_id", "status", "error_reason", "created_at", "completed_at",
+	}).AddRow("req-1", "user-1", requests.StatusFailed, longError, createdAt, nil)
+
+	mock.ExpectQuery(`SELECT request_id, user_id, status`).
+		WithArgs("", nil, nil, 50).
+		WillReturnRows(rows)
+
+	result, err := repository.List(context.Background(), adminlogs.ListOptions{Limit: 50})
+
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Len(t, []rune(result.Items[0].ErrorMessage), 500)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/handlers/admin_logs.go
+++ b/internal/handlers/admin_logs.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"astroapi/internal/adminlogs"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	defaultAdminLogsLimit = 50
+	maxAdminLogsLimit     = 200
+)
+
+// AdminLogsHandler обслуживает административные запросы к журналу генераций.
+type AdminLogsHandler struct {
+	repository adminlogs.Repository
+}
+
+type adminLogsListResponse struct {
+	Items      []adminlogs.LogEntry `json:"items"`
+	TotalCount int                  `json:"total_count"`
+}
+
+// NewAdminLogsHandler создает handler административного журнала генераций.
+// На вход принимает репозиторий журнала, на выход возвращает готовый handler.
+func NewAdminLogsHandler(repository adminlogs.Repository) *AdminLogsHandler {
+	return &AdminLogsHandler{repository: repository}
+}
+
+// RegisterAdminLogsRoutes регистрирует защищенные admin-роуты журнала генераций.
+// На вход принимает chi-роутер, admin token и handler; выходных значений нет.
+func RegisterAdminLogsRoutes(router chi.Router, adminToken string, handler *AdminLogsHandler) {
+	router.Route("/api/v1/admin/logs", func(router chi.Router) {
+		router.Use(AdminAuthMiddleware(adminToken))
+		router.Get("/", handler.ListLogs)
+	})
+}
+
+// ListLogs обрабатывает GET /api/v1/admin/logs.
+// На вход принимает ResponseWriter и Request, на выход пишет JSON-ответ со списком логов.
+func (h *AdminLogsHandler) ListLogs(w http.ResponseWriter, r *http.Request) {
+	options, err := parseAdminLogsListOptions(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	result, err := h.repository.List(r.Context(), options)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to fetch admin logs")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{
+		Message: "Admin logs fetched successfully",
+		Data: adminLogsListResponse{
+			Items:      sanitizeAdminLogEntries(result.Items),
+			TotalCount: result.TotalCount,
+		},
+	})
+}
+
+// parseAdminLogsListOptions парсит query-параметры списка admin logs.
+// На вход принимает HTTP-запрос, на выход возвращает опции фильтрации или ошибку.
+func parseAdminLogsListOptions(r *http.Request) (adminlogs.ListOptions, error) {
+	query := r.URL.Query()
+
+	status := strings.TrimSpace(query.Get("status"))
+	if status != "" && !adminlogs.IsValidStatus(status) {
+		return adminlogs.ListOptions{}, errors.New("status must be one of: pending, processing, completed, failed")
+	}
+
+	fromTime, err := parseOptionalRFC3339(query.Get("from"), "from")
+	if err != nil {
+		return adminlogs.ListOptions{}, err
+	}
+
+	toTime, err := parseOptionalRFC3339(query.Get("to"), "to")
+	if err != nil {
+		return adminlogs.ListOptions{}, err
+	}
+	if fromTime != nil && toTime != nil && fromTime.After(*toTime) {
+		return adminlogs.ListOptions{}, errors.New("from must be before or equal to to")
+	}
+
+	limit, err := parseBoundedPositiveInt(query.Get("limit"), defaultAdminLogsLimit, 1, maxAdminLogsLimit, "limit")
+	if err != nil {
+		return adminlogs.ListOptions{}, err
+	}
+
+	return adminlogs.ListOptions{
+		Status: status,
+		From:   fromTime,
+		To:     toTime,
+		Limit:  limit,
+	}, nil
+}
+
+// parseOptionalRFC3339 парсит необязательную ISO 8601 дату из query-параметра.
+// На вход принимает сырое значение и имя поля, на выход возвращает время или ошибку.
+func parseOptionalRFC3339(rawValue, fieldName string) (*time.Time, error) {
+	rawValue = strings.TrimSpace(rawValue)
+	if rawValue == "" {
+		return nil, nil
+	}
+
+	parsedValue, err := time.Parse(time.RFC3339, rawValue)
+	if err != nil {
+		return nil, errors.New(fieldName + " must be a valid ISO 8601 timestamp")
+	}
+
+	return &parsedValue, nil
+}
+
+// sanitizeAdminLogEntries подготавливает записи журнала к HTTP-ответу.
+// На вход принимает записи журнала, на выход возвращает копию с обрезанными error_message.
+func sanitizeAdminLogEntries(items []adminlogs.LogEntry) []adminlogs.LogEntry {
+	result := make([]adminlogs.LogEntry, len(items))
+	copy(result, items)
+
+	for i := range result {
+		result[i].ErrorMessage = adminlogs.TruncateErrorMessage(result[i].ErrorMessage)
+	}
+
+	return result
+}

--- a/internal/handlers/admin_logs_test.go
+++ b/internal/handlers/admin_logs_test.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"astroapi/internal/adminlogs"
+	"astroapi/internal/requests"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type fakeAdminLogsRepository struct {
+	items       []adminlogs.LogEntry
+	called      bool
+	lastOptions adminlogs.ListOptions
+}
+
+// List возвращает тестовые admin logs с учетом статуса и лимита.
+// На вход принимает контекст и опции фильтрации, на выход возвращает список и счетчик.
+func (r *fakeAdminLogsRepository) List(_ context.Context, options adminlogs.ListOptions) (adminlogs.ListResult, error) {
+	r.called = true
+	r.lastOptions = options
+
+	filtered := make([]adminlogs.LogEntry, 0, len(r.items))
+	for _, item := range r.items {
+		if options.Status != "" && item.Status != options.Status {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	totalCount := len(filtered)
+	if options.Limit < len(filtered) {
+		filtered = filtered[:options.Limit]
+	}
+
+	return adminlogs.ListResult{Items: filtered, TotalCount: totalCount}, nil
+}
+
+// newAdminLogsTestMux создает chi-роутер для тестов admin logs.
+// На вход принимает репозиторий, на выход возвращает настроенный роутер.
+func newAdminLogsTestMux(repository adminlogs.Repository) chi.Router {
+	router := chi.NewRouter()
+	RegisterAdminLogsRoutes(router, testAdminToken, NewAdminLogsHandler(repository))
+	return router
+}
+
+// decodeAdminLogsData декодирует data из JSON-ответа admin logs.
+// На вход принимает тест и recorder, на выход возвращает data-объект ответа.
+func decodeAdminLogsData(t *testing.T, response *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+
+	var envelope Response
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	data, ok := envelope.Data.(map[string]any)
+	if !ok {
+		t.Fatal("expected response data to be an object")
+	}
+
+	return data
+}
+
+// TestListAdminLogsFiltersByFailedStatus проверяет фильтр status=failed.
+// На вход принимает тестовый контекст, на выход проверяет HTTP-ответ handler.
+func TestListAdminLogsFiltersByFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	repository := &fakeAdminLogsRepository{items: []adminlogs.LogEntry{
+		{RequestID: "req-1", UserID: "user-1", Status: requests.StatusFailed, CreatedAt: now},
+		{RequestID: "req-2", UserID: "user-2", Status: requests.StatusCompleted, CreatedAt: now},
+	}}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs?status=failed", nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	newAdminLogsTestMux(repository).ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	data := decodeAdminLogsData(t, response)
+	items, ok := data["items"].([]any)
+	if !ok {
+		t.Fatal("expected items to be a list")
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one failed item, got %d", len(items))
+	}
+
+	item, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatal("expected first item to be an object")
+	}
+	if item["status"] != requests.StatusFailed {
+		t.Fatalf("expected failed status, got %v", item["status"])
+	}
+	if data["total_count"] != float64(1) {
+		t.Fatalf("expected total_count=1, got %v", data["total_count"])
+	}
+}
+
+// TestListAdminLogsRejectsLimitOverMax проверяет ошибку limit=201.
+// На вход принимает тестовый контекст, на выход проверяет статус 400 и отсутствие вызова репозитория.
+func TestListAdminLogsRejectsLimitOverMax(t *testing.T) {
+	t.Parallel()
+
+	repository := &fakeAdminLogsRepository{}
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs?limit=201", nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	newAdminLogsTestMux(repository).ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, response.Code)
+	}
+	if repository.called {
+		t.Fatal("repository must not be called for invalid limit")
+	}
+}
+
+// TestListAdminLogsTruncatesErrorMessage проверяет обрезку error_message в HTTP-ответе.
+// На вход принимает тестовый контекст, на выход проверяет длину error_message.
+func TestListAdminLogsTruncatesErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	repository := &fakeAdminLogsRepository{items: []adminlogs.LogEntry{
+		{
+			RequestID:    "req-1",
+			UserID:       "user-1",
+			Status:       requests.StatusFailed,
+			ErrorMessage: strings.Repeat("x", 501),
+			CreatedAt:    time.Now().UTC(),
+		},
+	}}
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs", nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	newAdminLogsTestMux(repository).ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	data := decodeAdminLogsData(t, response)
+	items := data["items"].([]any)
+	item := items[0].(map[string]any)
+	errorMessage, ok := item["error_message"].(string)
+	if !ok {
+		t.Fatal("expected error_message to be a string")
+	}
+	if len([]rune(errorMessage)) != 500 {
+		t.Fatalf("expected error_message length 500, got %d", len([]rune(errorMessage)))
+	}
+}

--- a/internal/handlers/processors.go
+++ b/internal/handlers/processors.go
@@ -126,7 +126,7 @@ func beginRequestProcessing(
 }
 
 // ProfileProcessor обрабатывает сообщения astro.events.profile.
-// Сохраняет пользователя (с шифрованием birth_date) и обновляет generation_results.
+// Сохраняет пользователя (с шифрованием birth_date) и обновляет requests_log.
 type ProfileProcessor struct {
 	userRepo     user.Repository
 	requestsRepo requests.Repository
@@ -182,7 +182,7 @@ func (p *ProfileProcessor) markFailed(ctx context.Context, requestID string, err
 }
 
 // RecommendProcessor обрабатывает сообщения astro.events.recommend.
-// Строит рекомендацию через AlisaAI и пишет результат в generation_results.
+// Строит рекомендацию через AlisaAI и пишет результат в requests_log.
 type RecommendProcessor struct {
 	userRepo     user.Repository
 	requestsRepo requests.Repository

--- a/internal/requests/postgres_repository.go
+++ b/internal/requests/postgres_repository.go
@@ -12,58 +12,40 @@ type PostgresRepository struct {
 	db *sql.DB
 }
 
+// NewPostgresRepository создает PostgreSQL-репозиторий requests_log.
+// На вход принимает соединение с БД, на выход возвращает готовый репозиторий.
 func NewPostgresRepository(db *sql.DB) *PostgresRepository {
 	return &PostgresRepository{db: db}
 }
 
+// Create создает новую запись запроса в requests_log.
+// На вход принимает контекст и данные запроса, на выход возвращает ошибку записи.
 func (r *PostgresRepository) Create(ctx context.Context, req Request) error {
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin create request tx: %w", err)
-	}
-
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	const requestQuery = `
+	const query = `
 		INSERT INTO requests_log (request_id, user_id, scenario, status, attempt_count)
 		VALUES ($1, $2, $3, $4, $5)
 	`
-	if _, err = tx.ExecContext(ctx, requestQuery,
+	if _, err := r.db.ExecContext(ctx, query,
 		req.RequestID, req.UserID, req.Scenario, req.Status, req.AttemptCount,
 	); err != nil {
 		return fmt.Errorf("insert requests_log: %w", err)
 	}
-
-	const resultQuery = `
-		INSERT INTO generation_results (request_id, status)
-		VALUES ($1, $2)
-	`
-	if _, err = tx.ExecContext(ctx, resultQuery, req.RequestID, StatusPending); err != nil {
-		return fmt.Errorf("insert generation_results: %w", err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("commit create request tx: %w", err)
-	}
-	committed = true
 	return nil
 }
 
+// StartProcessing атомарно переводит запрос из pending в processing.
+// На вход принимает контекст и request_id, на выход возвращает флаг успешного старта и ошибку.
 func (r *PostgresRepository) StartProcessing(ctx context.Context, requestID string) (bool, error) {
 	const query = `
-		UPDATE generation_results
+		UPDATE requests_log
 		SET status     = $2,
-		    updated_at = CURRENT_TIMESTAMP
+		    updated_at = CURRENT_TIMESTAMP,
+		    completed_at = NULL
 		WHERE request_id = $1 AND status = $3
 	`
 	res, err := r.db.ExecContext(ctx, query, requestID, StatusProcessing, StatusPending)
 	if err != nil {
-		return false, fmt.Errorf("start processing generation_results: %w", err)
+		return false, fmt.Errorf("start processing requests_log: %w", err)
 	}
 	rows, err := res.RowsAffected()
 	if err != nil {
@@ -72,79 +54,49 @@ func (r *PostgresRepository) StartProcessing(ctx context.Context, requestID stri
 	return rows > 0, nil
 }
 
+// UpdateStatus обновляет статус, результат и ошибку запроса в requests_log.
+// На вход принимает контекст, request_id, новый статус, JSON-результат и текст ошибки; на выход возвращает ошибку обновления.
 func (r *PostgresRepository) UpdateStatus(ctx context.Context, requestID, status string, result []byte, errReason string) error {
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin update request tx: %w", err)
-	}
-
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
 	var resultArg any
 	if len(result) > 0 {
 		resultArg = string(result)
 	}
 
-	const generationQuery = `
-		UPDATE generation_results
-		SET status         = $2,
-		    result_payload = COALESCE($3::jsonb, result_payload),
-		    error_reason   = NULLIF($4, ''),
-		    updated_at     = CURRENT_TIMESTAMP
-		WHERE request_id = $1
-	`
-	res, err := tx.ExecContext(ctx, generationQuery, requestID, status, resultArg, errReason)
-	if err != nil {
-		return fmt.Errorf("update generation_results: %w", err)
-	}
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("rows affected generation_results: %w", err)
-	}
-	if rows == 0 {
-		return ErrNotFound
-	}
-
-	const requestQuery = `
+	const query = `
 		UPDATE requests_log
 		SET status         = $2,
 		    result_payload = COALESCE($3::jsonb, result_payload),
 		    error_reason   = NULLIF($4, ''),
 		    attempt_count  = attempt_count + 1,
-		    updated_at     = CURRENT_TIMESTAMP
+		    updated_at     = CURRENT_TIMESTAMP,
+		    completed_at   = CASE
+		        WHEN $2 IN ('completed', 'failed') THEN CURRENT_TIMESTAMP
+		        ELSE NULL
+		    END
 		WHERE request_id = $1
 	`
-	res, err = tx.ExecContext(ctx, requestQuery, requestID, status, resultArg, errReason)
+	res, err := r.db.ExecContext(ctx, query, requestID, status, resultArg, errReason)
 	if err != nil {
 		return fmt.Errorf("update requests_log: %w", err)
 	}
-	rows, err = res.RowsAffected()
+	rows, err := res.RowsAffected()
 	if err != nil {
 		return fmt.Errorf("rows affected requests_log: %w", err)
 	}
 	if rows == 0 {
 		return ErrNotFound
 	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("commit update request tx: %w", err)
-	}
-	committed = true
 	return nil
 }
 
+// Get возвращает состояние запроса из requests_log по request_id.
+// На вход принимает контекст и request_id, на выход возвращает данные запроса или ошибку.
 func (r *PostgresRepository) Get(ctx context.Context, requestID string) (Request, error) {
 	const query = `
-		SELECT rl.request_id, rl.user_id, rl.scenario, gr.status, rl.attempt_count,
-		       COALESCE(gr.error_reason, ''), COALESCE(gr.result_payload::text, '')
-		FROM generation_results gr
-		JOIN requests_log rl ON rl.request_id = gr.request_id
-		WHERE gr.request_id = $1
+		SELECT request_id, user_id, scenario, status, attempt_count,
+		       COALESCE(error_reason, ''), COALESCE(result_payload::text, '')
+		FROM requests_log
+		WHERE request_id = $1
 	`
 	row := r.db.QueryRowContext(ctx, query, requestID)
 
@@ -157,7 +109,7 @@ func (r *PostgresRepository) Get(ctx context.Context, requestID string) (Request
 		if errors.Is(err, sql.ErrNoRows) {
 			return Request{}, ErrNotFound
 		}
-		return Request{}, fmt.Errorf("scan generation_results: %w", err)
+		return Request{}, fmt.Errorf("scan requests_log: %w", err)
 	}
 	if resultText != "" {
 		req.Result = []byte(resultText)

--- a/internal/requests/postgres_repository_test.go
+++ b/internal/requests/postgres_repository_test.go
@@ -24,14 +24,9 @@ func TestCreate_Success(t *testing.T) {
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectBegin()
 	mock.ExpectExec(`INSERT INTO requests_log`).
 		WithArgs("req-1", "u-1", "profile", requests.StatusPending, 0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(`INSERT INTO generation_results`).
-		WithArgs("req-1", requests.StatusPending).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
 
 	err := repo.Create(context.Background(), requests.Request{
 		RequestID: "req-1",
@@ -43,40 +38,13 @@ func TestCreate_Success(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestCreate_GenerationResultsError(t *testing.T) {
-	t.Parallel()
-	repo, db, mock := newRepo(t)
-	defer db.Close()
-
-	mock.ExpectBegin()
-	mock.ExpectExec(`INSERT INTO requests_log`).
-		WithArgs("req-1", "u-1", "profile", requests.StatusPending, 0).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(`INSERT INTO generation_results`).
-		WithArgs("req-1", requests.StatusPending).
-		WillReturnError(errors.New("conn refused"))
-	mock.ExpectRollback()
-
-	err := repo.Create(context.Background(), requests.Request{
-		RequestID: "req-1",
-		UserID:    "u-1",
-		Scenario:  "profile",
-		Status:    requests.StatusPending,
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "insert generation_results")
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
 func TestCreate_DBError(t *testing.T) {
 	t.Parallel()
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectBegin()
 	mock.ExpectExec(`INSERT INTO requests_log`).
 		WillReturnError(errors.New("conn refused"))
-	mock.ExpectRollback()
 
 	err := repo.Create(context.Background(), requests.Request{RequestID: "x"})
 	require.Error(t, err)
@@ -90,14 +58,9 @@ func TestUpdateStatus_Completed_WithResult(t *testing.T) {
 	defer db.Close()
 
 	payload := []byte(`{"text":"ok"}`)
-	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE generation_results`).
-		WithArgs("req-1", requests.StatusCompleted, string(payload), "").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`UPDATE requests_log`).
 		WithArgs("req-1", requests.StatusCompleted, string(payload), "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectCommit()
 
 	err := repo.UpdateStatus(context.Background(), "req-1", requests.StatusCompleted, payload, "")
 	require.NoError(t, err)
@@ -109,14 +72,9 @@ func TestUpdateStatus_Failed_WithReason(t *testing.T) {
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE generation_results`).
-		WithArgs("req-2", requests.StatusFailed, nil, "user not found").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`UPDATE requests_log`).
 		WithArgs("req-2", requests.StatusFailed, nil, "user not found").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectCommit()
 
 	err := repo.UpdateStatus(context.Background(), "req-2", requests.StatusFailed, nil, "user not found")
 	require.NoError(t, err)
@@ -128,11 +86,9 @@ func TestUpdateStatus_NotFound(t *testing.T) {
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE generation_results`).
+	mock.ExpectExec(`UPDATE requests_log`).
 		WithArgs("ghost", requests.StatusCompleted, nil, "").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectRollback()
 
 	err := repo.UpdateStatus(context.Background(), "ghost", requests.StatusCompleted, nil, "")
 	require.ErrorIs(t, err, requests.ErrNotFound)
@@ -148,7 +104,7 @@ func TestGet_Found(t *testing.T) {
 		"request_id", "user_id", "scenario", "status", "attempt_count", "error_reason", "result_payload",
 	}).AddRow("req-1", "u-1", "profile", requests.StatusCompleted, 1, "", `{"ok":true}`)
 
-	mock.ExpectQuery(`FROM generation_results`).
+	mock.ExpectQuery(`FROM requests_log`).
 		WithArgs("req-1").
 		WillReturnRows(rows)
 
@@ -166,7 +122,7 @@ func TestGet_NotFound(t *testing.T) {
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectQuery(`FROM generation_results`).
+	mock.ExpectQuery(`FROM requests_log`).
 		WithArgs("nope").
 		WillReturnError(sql.ErrNoRows)
 
@@ -183,7 +139,7 @@ func TestGet_EmptyResultPayload(t *testing.T) {
 		"request_id", "user_id", "scenario", "status", "attempt_count", "error_reason", "result_payload",
 	}).AddRow("req-2", "u-1", "profile", requests.StatusPending, 0, "", "")
 
-	mock.ExpectQuery(`FROM generation_results`).
+	mock.ExpectQuery(`FROM requests_log`).
 		WithArgs("req-2").
 		WillReturnRows(rows)
 
@@ -197,7 +153,7 @@ func TestStartProcessing_PendingToProcessing(t *testing.T) {
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectExec(`UPDATE generation_results`).
+	mock.ExpectExec(`UPDATE requests_log`).
 		WithArgs("req-1", requests.StatusProcessing, requests.StatusPending).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -212,7 +168,7 @@ func TestStartProcessing_StatusConflict(t *testing.T) {
 	repo, db, mock := newRepo(t)
 	defer db.Close()
 
-	mock.ExpectExec(`UPDATE generation_results`).
+	mock.ExpectExec(`UPDATE requests_log`).
 		WithArgs("req-1", requests.StatusProcessing, requests.StatusPending).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -1,5 +1,5 @@
 // Package requests хранит журнал обращений пользователей и результаты генерации.
-// requests_log используется для аудита, generation_results — для идемпотентности воркера.
+// requests_log используется как единый источник статусов, результата и ошибок обработки.
 package requests
 
 import (
@@ -16,8 +16,7 @@ var (
 
 // Статусы обработки.
 const (
-	StatusPending = "pending"
-	StatusAccepted   = StatusPending
+	StatusPending    = "pending"
 	StatusProcessing = "processing"
 	StatusCompleted  = "completed"
 	StatusFailed     = "failed"
@@ -34,7 +33,7 @@ type Request struct {
 	Result       []byte // JSON payload
 }
 
-// Repository описывает журнал запросов и таблицу generation_results.
+// Repository описывает операции над единым журналом requests_log.
 type Repository interface {
 	Create(ctx context.Context, req Request) error
 	StartProcessing(ctx context.Context, requestID string) (bool, error)

--- a/migrations/20260511120000_fix_timestamps_and_constraints.sql
+++ b/migrations/20260511120000_fix_timestamps_and_constraints.sql
@@ -21,7 +21,7 @@ ALTER TABLE requests_log
 -- CHECK constraint: защищает от попадания мусора в status
 ALTER TABLE requests_log
     ADD CONSTRAINT chk_requests_log_status
-    CHECK (status IN ('accepted', 'processing', 'completed', 'failed'));
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed'));
 
 -- CHECK constraint: scenario
 ALTER TABLE requests_log

--- a/migrations/20260513120000_use_requests_log_for_generation_results.sql
+++ b/migrations/20260513120000_use_requests_log_for_generation_results.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+ALTER TABLE requests_log
+    DROP CONSTRAINT IF EXISTS chk_requests_log_status;
+
+ALTER TABLE requests_log
+    ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+    IF to_regclass('public.generation_results') IS NOT NULL THEN
+        UPDATE requests_log AS rl
+        SET status = gr.status,
+            result_payload = COALESCE(gr.result_payload, rl.result_payload),
+            error_reason = COALESCE(gr.error_reason, rl.error_reason),
+            updated_at = GREATEST(rl.updated_at, gr.updated_at),
+            completed_at = CASE
+                WHEN gr.status IN ('completed', 'failed')
+                    THEN COALESCE(rl.completed_at, gr.updated_at, CURRENT_TIMESTAMP)
+                ELSE rl.completed_at
+            END
+        FROM generation_results AS gr
+        WHERE rl.request_id = gr.request_id;
+    END IF;
+END $$;
+
+ALTER TABLE requests_log
+    ADD CONSTRAINT chk_requests_log_status
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed'));
+
+DROP TABLE IF EXISTS generation_results;
+
+-- +goose Down
+CREATE TABLE IF NOT EXISTS generation_results (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    request_id UUID NOT NULL UNIQUE REFERENCES requests_log(request_id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    result_payload JSONB,
+    error_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_generation_results_status
+    ON generation_results (status, created_at DESC);
+
+INSERT INTO generation_results (request_id, status, result_payload, error_reason, created_at, updated_at)
+SELECT request_id, status, result_payload, error_reason, created_at, updated_at
+FROM requests_log
+ON CONFLICT (request_id) DO UPDATE SET
+    status = EXCLUDED.status,
+    result_payload = EXCLUDED.result_payload,
+    error_reason = EXCLUDED.error_reason,
+    updated_at = EXCLUDED.updated_at;
+
+ALTER TABLE requests_log
+    DROP CONSTRAINT IF EXISTS chk_requests_log_status;
+
+ALTER TABLE requests_log
+    ADD CONSTRAINT chk_requests_log_status
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed'));
+
+ALTER TABLE requests_log
+    DROP COLUMN IF EXISTS completed_at;


### PR DESCRIPTION
- Перевел requests.Repository обратно на единую таблицу requests_log
- Добавил миграцию для completed_at, переноса данных из generation_results и удаления лишней таблицы
- Реализовал GET /api/v1/admin/logs с фильтрами status/from/to и limit
- Добавил total_count и обрезку error_message до 500 символов
- Обновил Swagger и тесты для admin logs