### PR TITLE
[AB-93] Fix /products

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -200,7 +200,7 @@ func run() error {
 	profileHandler := handlers.NewProfileHandler(publisher, requestsRepo, personalDataUC, zapLogger)
 	recommendHandler := handlers.NewRecommendHandler(publisher, userRepo, rulesRepo, aiClient, astroClient, requestsRepo, zapLogger)
 	adminRulesHandler := handlers.NewAdminRulesHandler(rulesRepo)
-	adminProductsHandler := handlers.NewAdminProductsHandler(productsRepo, nil)
+	adminProductsHandler := handlers.NewAdminProductsHandler(productsRepo, nil, zapLogger)
 	adminLogsHandler := handlers.NewAdminLogsHandler(adminLogsRepo)
 	authHandler := handlers.NewAuthHandler(adminRepo, cfg.AdminToken)
 	feedbackHandler := handlers.NewFeedbackHandler(feedbackrepo.NewFeedbackRepository(db.DB))

--- a/internal/handlers/admin_products.go
+++ b/internal/handlers/admin_products.go
@@ -11,6 +11,7 @@ import (
 	"astroapi/internal/products"
 
 	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
 )
 
 const (
@@ -22,6 +23,7 @@ const (
 type AdminProductsHandler struct {
 	repository       products.Repository
 	cacheInvalidator products.CacheInvalidator
+	logger           *zap.Logger
 }
 
 type adminProductsListResponse struct {
@@ -42,8 +44,11 @@ type adminProductPatchRequest struct {
 	Tags  *[]string `json:"tags"`
 }
 
-func NewAdminProductsHandler(repository products.Repository, cacheInvalidator products.CacheInvalidator) *AdminProductsHandler {
-	return &AdminProductsHandler{repository: repository, cacheInvalidator: cacheInvalidator}
+func NewAdminProductsHandler(repository products.Repository, cacheInvalidator products.CacheInvalidator, logger *zap.Logger) *AdminProductsHandler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &AdminProductsHandler{repository: repository, cacheInvalidator: cacheInvalidator, logger: logger}
 }
 
 func RegisterAdminProductsRoutes(router chi.Router, adminToken string, handler *AdminProductsHandler) {
@@ -64,8 +69,11 @@ func (h *AdminProductsHandler) ListProducts(w http.ResponseWriter, r *http.Reque
 
 	result, err := h.repository.List(r.Context(), options)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to fetch products")
+		writeError(w, http.StatusInternalServerError, "db_unavailable")
 		return
+	}
+	if len(result.Items) == 0 && result.TotalCount == 0 {
+		h.logger.Debug("no products found", zap.Any("filters", options))
 	}
 
 	writeJSON(w, http.StatusOK, Response{

--- a/internal/handlers/admin_products_test.go
+++ b/internal/handlers/admin_products_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -16,7 +17,8 @@ import (
 )
 
 type fakeProductsRepository struct {
-	items map[string]products.Product
+	items   map[string]products.Product
+	listErr error
 }
 
 func newFakeProductsRepository(items []products.Product) *fakeProductsRepository {
@@ -28,6 +30,10 @@ func newFakeProductsRepository(items []products.Product) *fakeProductsRepository
 }
 
 func (r *fakeProductsRepository) List(_ context.Context, options products.ListOptions) (products.ListResult, error) {
+	if r.listErr != nil {
+		return products.ListResult{}, r.listErr
+	}
+
 	filtered := make([]products.Product, 0, len(r.items))
 	for _, item := range r.items {
 		if options.Category != "" && item.Category != options.Category {
@@ -89,7 +95,7 @@ func (i *fakeProductCacheInvalidator) InvalidateProduct(_ context.Context, sku s
 
 func newAdminProductsTestMux(repository products.Repository, invalidator products.CacheInvalidator) chi.Router {
 	router := chi.NewRouter()
-	RegisterAdminProductsRoutes(router, testAdminToken, NewAdminProductsHandler(repository, invalidator))
+	RegisterAdminProductsRoutes(router, testAdminToken, NewAdminProductsHandler(repository, invalidator, nil))
 	return router
 }
 
@@ -167,6 +173,86 @@ func TestListProductsFiltersByCategory(t *testing.T) {
 	}
 	if item["category"] != "rings" {
 		t.Fatalf("expected rings category, got %v", item["category"])
+	}
+}
+
+func TestListProductsUnknownTagReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	repository := newFakeProductsRepository([]products.Product{
+		{
+			SKU:       "sku-1",
+			Name:      "Silk scarf",
+			Price:     1200,
+			Tags:      []string{"silk"},
+			Category:  "scarves",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/products?tags=unknown", nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	mux := newAdminProductsTestMux(repository, nil)
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	var envelope Response
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	payload, ok := envelope.Data.(map[string]any)
+	if !ok {
+		t.Fatal("expected response data to be a map")
+	}
+
+	items, ok := payload["items"].([]any)
+	if !ok {
+		t.Fatal("expected response data.items to be a list")
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty products list, got %d", len(items))
+	}
+
+	metadata, ok := payload["metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("expected response data.metadata to be a map")
+	}
+	if metadata["total_records"] != float64(0) {
+		t.Fatalf("expected total_records=0, got %v", metadata["total_records"])
+	}
+}
+
+func TestListProductsDBErrorReturnsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	repository := newFakeProductsRepository(nil)
+	repository.listErr = errors.New("connection refused")
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/products?tags=silk", nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	response := httptest.NewRecorder()
+
+	mux := newAdminProductsTestMux(repository, nil)
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, response.Code)
+	}
+
+	var envelope Response
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Error != "db_unavailable" {
+		t.Fatalf("expected db_unavailable error, got %q", envelope.Error)
 	}
 }
 


### PR DESCRIPTION
В хэндлере GET /api/v1/admin/products:
Если запрос валиден, но результат пустой — возвращается 200 OK с {items: [], total: 0}
5xx только на реальные ошибки БД/сети
Добавил лог: logger.Debug("no products found", zap.Any("filters", filters))