### PR TITLE
DB-03: GIN-индекс и autovacuum для products

### DIFF
--- a/migrations/20260510161028_create_gin_index.sql
+++ b/migrations/20260510161028_create_gin_index.sql
@@ -1,0 +1,5 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_products_tags ON products USING GIN (tags);
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_products_tags;

--- a/migrations/20260510161109_set_autovacuum_products.sql
+++ b/migrations/20260510161109_set_autovacuum_products.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+ALTER TABLE products SET (
+    autovacuum_vacuum_scale_factor = 0.05,
+    autovacuum_vacuum_threshold = 1000,
+    autovacuum_analyze_scale_factor = 0.05,
+    autovacuum_analyze_threshold = 500
+);
+-- +goose Down
+ALTER TABLE products RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_scale_factor,
+    autovacuum_analyze_threshold
+);


### PR DESCRIPTION
Что сделано:

· Добавлен GIN-индекс idx_products_tags с опцией CONCURRENTLY (без блокировки таблицы).
· Настроен autovacuum для таблицы products (параметры для частых обновлений тегов).
· Приложен нагрузочный тест: EXPLAIN ANALYZE показывает Bitmap Index Scan, индекс используется.

DoD:

· Индекс создаётся CONCURRENTLY
· EXPLAIN ANALYZE – Bitmap Index Scan
· Нагрузочный тест задокументирован
· autovacuum настроен

Результат нагрузочного теста (100k строк):

· Запрос с ?| выполняется с индексом, план содержит Bitmap Index Scan. Время ~240 мс (основная нагрузка от подзапроса, не от индекса). 
<img width="799" height="397" alt="Снимок экрана 2026-05-10 в 19 15 06" src="https://github.com/user-attachments/assets/3c9d36c6-164f-4327-90af-769880f1e90c" />
