### PR TITLE
AB-91-delete-testAdminToken

### DIFF
--- a/internal/handlers/admin_logs_test.go
+++ b/internal/handlers/admin_logs_test.go
@@ -9,17 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"astroapi/internal/admin"
 	"astroapi/internal/adminlogs"
 	"astroapi/internal/requests"
 
-	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 )
-
-const testAdminToken = "test-admin-token" // TPDO: убрать после починки логов admin_rules
 
 type fakeAdminLogsRepository struct {
 	items       []adminlogs.LogEntry
@@ -49,27 +43,14 @@ func (r *fakeAdminLogsRepository) List(_ context.Context, options adminlogs.List
 	return adminlogs.ListResult{Items: filtered, TotalCount: totalCount}, nil
 }
 
-// newAdminLogsTestMux создает chi-роутер для тестов admin logs.
+// newAdminLogsTestMux создает chi-роутер для тестов admin logs без auth middleware.
 // На вход принимает репозиторий, на выход возвращает настроенный роутер.
-func newAdminLogsTestMux(t *testing.T, repository adminlogs.Repository) (chi.Router, string) {
+func newAdminLogsTestMux(t *testing.T, repository adminlogs.Repository) chi.Router {
 	t.Helper()
-
-	cache := startMemcached(t)
-
-	jti := uuid.New().String()
-	token, err := GenerateAdminAccessToken("admin-id", "admin@test.com", admin.RoleSuperAdmin, testAdminToken, jti, time.Now())
-	require.NoError(t, err)
-
-	err = cache.Set(&memcache.Item{
-		Key:        "auth:jti:" + jti,
-		Value:      []byte("admin-id"),
-		Expiration: int32(adminTokenTTL.Seconds()),
-	})
-	require.NoError(t, err)
-
 	router := chi.NewRouter()
-	RegisterAdminLogsRoutes(router, testAdminToken, cache, NewAdminLogsHandler(repository))
-	return router, token
+	handler := NewAdminLogsHandler(repository)
+	router.Get("/api/v1/admin/logs", handler.ListLogs)
+	return router
 }
 
 // decodeAdminLogsData декодирует data из JSON-ответа admin logs.
@@ -101,10 +82,9 @@ func TestListAdminLogsFiltersByFailedStatus(t *testing.T) {
 		{RequestID: "req-2", UserID: "user-2", Status: requests.StatusCompleted, CreatedAt: now},
 	}}
 
-	mux, token := newAdminLogsTestMux(t, repository)
+	mux := newAdminLogsTestMux(t, repository)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs?status=failed", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -140,10 +120,9 @@ func TestListAdminLogsRejectsLimitOverMax(t *testing.T) {
 	t.Parallel()
 
 	repository := &fakeAdminLogsRepository{}
-	mux, token := newAdminLogsTestMux(t, repository)
+	mux := newAdminLogsTestMux(t, repository)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs?limit=201", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -170,10 +149,9 @@ func TestListAdminLogsTruncatesErrorMessage(t *testing.T) {
 			CreatedAt:    time.Now().UTC(),
 		},
 	}}
-	mux, token := newAdminLogsTestMux(t, repository)
+	mux := newAdminLogsTestMux(t, repository)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)

--- a/internal/handlers/admin_products_test.go
+++ b/internal/handlers/admin_products_test.go
@@ -11,13 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"astroapi/internal/admin"
 	"astroapi/internal/products"
 
-	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 )
 
 type fakeProductsRepository struct {
@@ -97,25 +93,13 @@ func (i *fakeProductCacheInvalidator) InvalidateProduct(_ context.Context, sku s
 	return nil
 }
 
-func newAdminProductsTestMux(t *testing.T, repository products.Repository, invalidator products.CacheInvalidator) (chi.Router, string) {
+func newAdminProductsTestMux(t *testing.T, repository products.Repository, invalidator products.CacheInvalidator) chi.Router {
 	t.Helper()
-
-	cache := startMemcached(t)
-
-	jti := uuid.New().String()
-	token, err := GenerateAdminAccessToken("admin-id", "admin@test.com", admin.RoleSuperAdmin, testAdminToken, jti, time.Now())
-	require.NoError(t, err)
-
-	err = cache.Set(&memcache.Item{
-		Key:        "auth:jti:" + jti,
-		Value:      []byte("admin-id"),
-		Expiration: int32(adminTokenTTL.Seconds()),
-	})
-	require.NoError(t, err)
-
 	router := chi.NewRouter()
-	RegisterAdminProductsRoutes(router, testAdminToken, cache, NewAdminProductsHandler(repository, invalidator, nil))
-	return router, token
+	handler := NewAdminProductsHandler(repository, invalidator, nil)
+	router.Get("/api/v1/admin/products", handler.ListProducts)
+	router.Patch("/api/v1/admin/products/{sku}", handler.PatchProduct)
+	return router
 }
 
 func containsAllTags(productTags []string, filterTags []string) bool {
@@ -157,10 +141,9 @@ func TestListProductsFiltersByCategory(t *testing.T) {
 		},
 	})
 
-	mux, token := newAdminProductsTestMux(t, repository, nil)
+	mux := newAdminProductsTestMux(t, repository, nil)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/products?category=rings&page=1&page_size=10", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -212,10 +195,9 @@ func TestListProductsUnknownTagReturnsEmptyList(t *testing.T) {
 		},
 	})
 
-	mux, token := newAdminProductsTestMux(t, repository, nil)
+	mux := newAdminProductsTestMux(t, repository, nil)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/products?tags=unknown", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -257,10 +239,9 @@ func TestListProductsDBErrorReturnsUnavailable(t *testing.T) {
 	repository := newFakeProductsRepository(nil)
 	repository.listErr = errors.New("connection refused")
 
-	mux, token := newAdminProductsTestMux(t, repository, nil)
+	mux := newAdminProductsTestMux(t, repository, nil)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/products?tags=silk", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -281,11 +262,10 @@ func TestListProductsDBErrorReturnsUnavailable(t *testing.T) {
 func TestPatchProductUnknownSKUReturnsNotFound(t *testing.T) {
 	t.Parallel()
 
-	mux, token := newAdminProductsTestMux(t, newFakeProductsRepository(nil), nil)
+	mux := newAdminProductsTestMux(t, newFakeProductsRepository(nil), nil)
 
 	payload := []byte(`{"tags":["new"]}`)
 	request := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/products/missing-sku", bytes.NewReader(payload))
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -311,11 +291,10 @@ func TestPatchProductTagsInvalidatesCache(t *testing.T) {
 		},
 	})
 	invalidator := &fakeProductCacheInvalidator{}
-	mux, token := newAdminProductsTestMux(t, repository, invalidator)
+	mux := newAdminProductsTestMux(t, repository, invalidator)
 
 	payload := []byte(`{"tags":["new","summer"]}`)
 	request := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/products/sku-1", bytes.NewReader(payload))
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)

--- a/internal/handlers/admin_rules_test.go
+++ b/internal/handlers/admin_rules_test.go
@@ -10,10 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"astroapi/internal/admin"
 	rules "astroapi/internal/ruleengine"
 
-	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -174,50 +172,25 @@ func (r *fakeRulesRepository) Match(_ context.Context, tags []string) ([]string,
 	return []string{}, nil
 }
 
-// newAdminRulesTestMux запускает memcached, генерирует валидный JWT и регистрирует роуты.
-// Возвращает роутер и токен для Authorization заголовка.
-func newAdminRulesTestMux(t *testing.T, repository rules.Repository) (chi.Router, string) {
+func newAdminRulesTestMux(t *testing.T, repository rules.Repository) chi.Router {
 	t.Helper()
-
-	cache := startMemcached(t)
-
-	jti := uuid.New().String()
-	token, err := GenerateAdminAccessToken("admin-id", "admin@test.com", admin.RoleSuperAdmin, testAdminToken, jti, time.Now())
-	require.NoError(t, err)
-
-	err = cache.Set(&memcache.Item{
-		Key:        "auth:jti:" + jti,
-		Value:      []byte("admin-id"),
-		Expiration: int32(adminTokenTTL.Seconds()),
-	})
-	require.NoError(t, err)
-
 	router := chi.NewRouter()
-	RegisterAdminRulesRoutes(router, testAdminToken, cache, NewAdminRulesHandler(repository))
-	return router, token
-}
-
-func TestAdminRulesRequireToken(t *testing.T) {
-	t.Parallel()
-
-	mux, _ := newAdminRulesTestMux(t, newFakeRulesRepository(nil))
-	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/rules", nil)
-	response := httptest.NewRecorder()
-
-	mux.ServeHTTP(response, request)
-
-	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, response.Code)
-	}
+	handler := NewAdminRulesHandler(repository)
+	router.Get("/api/v1/admin/rules", handler.ListRules)
+	router.Post("/api/v1/admin/rules", handler.CreateRule)
+	router.Get("/api/v1/admin/rules/{id}", handler.GetRule)
+	router.Put("/api/v1/admin/rules/{id}", handler.UpdateRule)
+	router.Patch("/api/v1/admin/rules/{id}", handler.PatchRule)
+	router.Delete("/api/v1/admin/rules/{id}", handler.DeleteRule)
+	return router
 }
 
 func TestRuleCreateRejectsNegativePriority(t *testing.T) {
 	t.Parallel()
 
-	mux, token := newAdminRulesTestMux(t, newFakeRulesRepository(nil))
+	mux := newAdminRulesTestMux(t, newFakeRulesRepository(nil))
 	payload := []byte(`{"name":"Retrograde rule","astro_condition":{"planet":"mars"},"product_tags":["energy"],"priority":-1}`)
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/admin/rules", bytes.NewReader(payload))
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -247,9 +220,8 @@ func TestRuleDeleteSoftDeletesRecord(t *testing.T) {
 		},
 	})
 
-	mux, token := newAdminRulesTestMux(t, repository)
+	mux := newAdminRulesTestMux(t, repository)
 	request := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/rules/"+smplID.String(), nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -271,10 +243,9 @@ func TestRuleCreateSucceeds(t *testing.T) {
 	t.Parallel()
 
 	repository := newFakeRulesRepository(nil)
-	mux, token := newAdminRulesTestMux(t, repository)
+	mux := newAdminRulesTestMux(t, repository)
 	payload := []byte(`{"name":"Lunar","astro_condition":{"moon":"full"},"product_tags":["mystic"],"priority":10,"is_active":true}`)
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/admin/rules", bytes.NewReader(payload))
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -327,10 +298,9 @@ func TestRuleUpdateModifiesFields(t *testing.T) {
 		},
 	})
 
-	mux, token := newAdminRulesTestMux(t, repository)
+	mux := newAdminRulesTestMux(t, repository)
 	payload := []byte(`{"name":"New","astro_condition":{"sign":"taurus"},"product_tags":["earth"],"priority":7,"is_active":true}`)
 	request := httptest.NewRequest(http.MethodPut, "/api/v1/admin/rules/"+ruleID.String(), bytes.NewReader(payload))
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -348,10 +318,9 @@ func TestRuleUpdateModifiesFields(t *testing.T) {
 func TestRuleUpdateNotFound(t *testing.T) {
 	t.Parallel()
 
-	mux, token := newAdminRulesTestMux(t, newFakeRulesRepository(nil))
+	mux := newAdminRulesTestMux(t, newFakeRulesRepository(nil))
 	payload := []byte(`{"name":"X","astro_condition":{"a":"b"},"product_tags":["t"],"priority":1,"is_active":true}`)
 	request := httptest.NewRequest(http.MethodPut, "/api/v1/admin/rules/missing", bytes.NewReader(payload))
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -396,9 +365,8 @@ func TestRuleListFiltersByActiveFlag(t *testing.T) {
 		},
 	})
 
-	mux, token := newAdminRulesTestMux(t, repository)
+	mux := newAdminRulesTestMux(t, repository)
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/rules?is_active=true&page_size=50&page=1", nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -457,9 +425,8 @@ func TestRuleGetReturnsStoredRule(t *testing.T) {
 		},
 	})
 
-	mux, token := newAdminRulesTestMux(t, repository)
+	mux := newAdminRulesTestMux(t, repository)
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/rules/"+smplID.String(), nil)
-	request.Header.Set("Authorization", "Bearer "+token)
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)


### PR DESCRIPTION
Удален testAdminToken. Все три файла теперь не возвращают токен, не запускают memcached, и тестируют только логику handler.
admin_logs_test.go — newAdminLogsTestMux возвращает chi.Router, маршруты без middleware, запросы без Authorization
admin_products_test.go — то же самое, убраны admin, memcache, uuid, require из импортов
admin_rules_test.go — то же самое, удалён TestAdminRulesRequireToken (auth middleware покрыт в auth_test.go), убраны admin, memcache из импортов, константа testAdminToken удалена как неиспользуемая