### PR TITLE
feature/AB-90-storing/receiving-an-astroprofile

### DIFF
--- a/internal/repositories/astro_profile_repo.go
+++ b/internal/repositories/astro_profile_repo.go
@@ -1,0 +1,12 @@
+package repositories
+
+import (
+	"context"
+
+	"astroapi/internal/repositories/domain"
+)
+
+type AstroProfileRepository interface {
+	ReceivingByHash(ctx context.Context, hash string) (*domain.AstroProfile, error)
+	Save(ctx context.Context, profile domain.AstroProfile) error
+}

--- a/internal/repositories/cache_astro_profile_repo.go
+++ b/internal/repositories/cache_astro_profile_repo.go
@@ -1,0 +1,89 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"astroapi/internal/repositories/domain"
+
+	"github.com/bradfitz/gomemcache/memcache"
+)
+
+type cacheAstroProfileRepo struct {
+	client *memcache.Client
+	ttl    int32
+}
+
+func NewCacheAstroProfileRepo(servers []string, ttl time.Duration) *cacheAstroProfileRepo {
+	return &cacheAstroProfileRepo{
+		client: memcache.New(servers...),
+		ttl:    int32(ttl.Seconds()),
+	}
+}
+
+func (r *cacheAstroProfileRepo) Save(ctx context.Context, profile domain.AstroProfile) error {
+	tracer := otel.Tracer("cache-astro-profile-repo")
+	repoctx, repoSpan := tracer.Start(ctx, "astro-profile.Save")
+	_ = repoctx
+	defer repoSpan.End()
+
+	if profile.ProfileHash == "" {
+		err := errors.New("profileHash cannot be empty")
+		repoSpan.RecordError(err)
+		return err
+	}
+	key := fmt.Sprintf("astro_profile:%s", profile.ProfileHash)
+	jsonData, err := json.Marshal(profile)
+	if err != nil {
+		err = fmt.Errorf("astro_profile serialization error: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
+	item := &memcache.Item{
+		Key:        key,
+		Value:      jsonData,
+		Expiration: r.ttl,
+	}
+
+	if err := r.client.Set(item); err != nil {
+		err = fmt.Errorf("memcached save error: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
+	return nil
+}
+func (r *cacheAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (*domain.AstroProfile, error) {
+	tracer := otel.Tracer("cache-astro-profile-repo")
+	_, repoSpan := tracer.Start(ctx, "astro-profile.ReceivingByHash")
+	defer repoSpan.End()
+
+	if hash == "" {
+		err := errors.New("profile hash must not be empty")
+		repoSpan.RecordError(err)
+		return nil, err
+	}
+	key := "astro_profile:" + hash
+
+	var p *domain.AstroProfile
+
+	item, err := r.client.Get(key)
+
+	if err == nil {
+		if unmarshalErr := json.Unmarshal(item.Value, &p); unmarshalErr != nil {
+			unmarshalErr := fmt.Errorf("data deserialization error: %w", unmarshalErr)
+			repoSpan.RecordError(unmarshalErr)
+			return nil, unmarshalErr
+		}
+	} else if !errors.Is(err, memcache.ErrCacheMiss) {
+		repoSpan.RecordError(err)
+		return nil, err
+	} else {
+		return nil, nil
+	}
+	return p, nil
+}

--- a/internal/repositories/cache_astro_profile_repo.go
+++ b/internal/repositories/cache_astro_profile_repo.go
@@ -19,7 +19,7 @@ type cacheAstroProfileRepo struct {
 	ttl    int32
 }
 
-func NewCacheAstroProfileRepo(servers []string, ttl time.Duration) *cacheAstroProfileRepo {
+func NewCacheAstroProfileRepo(servers []string, ttl time.Duration) AstroProfileRepository {
 	return &cacheAstroProfileRepo{
 		client: memcache.New(servers...),
 		ttl:    int32(ttl.Seconds()),

--- a/internal/repositories/cache_astro_profile_repo.go
+++ b/internal/repositories/cache_astro_profile_repo.go
@@ -16,13 +16,13 @@ import (
 
 type cacheAstroProfileRepo struct {
 	client *memcache.Client
-	ttl    int32
+	ttl    time.Duration
 }
 
 func NewCacheAstroProfileRepo(servers []string, ttl time.Duration) AstroProfileRepository {
 	return &cacheAstroProfileRepo{
 		client: memcache.New(servers...),
-		ttl:    int32(ttl.Seconds()),
+		ttl:    ttl,
 	}
 }
 
@@ -47,7 +47,7 @@ func (r *cacheAstroProfileRepo) Save(ctx context.Context, profile domain.AstroPr
 	item := &memcache.Item{
 		Key:        key,
 		Value:      jsonData,
-		Expiration: r.ttl,
+		Expiration: int32(r.ttl.Seconds()),
 	}
 
 	if err := r.client.Set(item); err != nil {
@@ -67,7 +67,7 @@ func (r *cacheAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string
 		repoSpan.RecordError(err)
 		return nil, err
 	}
-	key := "astro_profile:" + hash
+	key := fmt.Sprintf("astro_profile:%s", hash)
 
 	var p *domain.AstroProfile
 

--- a/internal/repositories/db_astro_profile_repo.go
+++ b/internal/repositories/db_astro_profile_repo.go
@@ -44,6 +44,12 @@ func (r *dbAstroProfileRepo) Save(ctx context.Context, profile domain.AstroProfi
 		repoSpan.RecordError(err)
 		return err
 	}
+	tx, err := r.db.BeginTx(repoctx, nil)
+	if err != nil {
+		err = fmt.Errorf("begin transaction: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
 
 	now := time.Now()
 	query := `INSERT INTO astro_profiles (id, user_id, profile_hash, dob_encrypted, consent_given, profile_data, created_at)
@@ -52,19 +58,25 @@ func (r *dbAstroProfileRepo) Save(ctx context.Context, profile domain.AstroProfi
               dob_encrypted = EXCLUDED.dob_encrypted,
               consent_given = EXCLUDED.consent_given,
               profile_data = EXCLUDED.profile_data;`
-	_, err = r.db.ExecContext(repoctx, query, profile.ID, profile.UserID, profile.ProfileHash, encryptedDob, profile.ConsentGiven, profileDataJSON, now)
+
+	_, err = tx.ExecContext(repoctx, query, profile.ID, profile.UserID, profile.ProfileHash, encryptedDob, profile.ConsentGiven, profileDataJSON, now)
 	if err != nil {
+		_ = tx.Rollback()
 		err := fmt.Errorf("error adding data to the astro_profile table: %w", err)
 		repoSpan.RecordError(err)
 		return err
 	}
-
+	if err := tx.Commit(); err != nil {
+		err := fmt.Errorf("commit transaction: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
 	return nil
 }
 
 func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (_ *domain.AstroProfile, retErr error) {
 	tracer := otel.Tracer("db-astro-profile-repo")
-	repoctx, repoSpan := tracer.Start(ctx, "astro-profile.ReceivingByHas")
+	repoctx, repoSpan := tracer.Start(ctx, "astro-profile.ReceivingByHash")
 	defer repoSpan.End()
 
 	if hash == "" {

--- a/internal/repositories/db_astro_profile_repo.go
+++ b/internal/repositories/db_astro_profile_repo.go
@@ -19,7 +19,7 @@ type dbAstroProfileRepo struct {
 	key []byte
 }
 
-func NewDbAstroProfileRepo(db *sql.DB, encryptionKey []byte) *dbAstroProfileRepo {
+func NewDbAstroProfileRepo(db *sql.DB, encryptionKey []byte) AstroProfileRepository {
 	return &dbAstroProfileRepo{
 		db:  db,
 		key: encryptionKey,
@@ -62,7 +62,7 @@ func (r *dbAstroProfileRepo) Save(ctx context.Context, profile domain.AstroProfi
 	return nil
 }
 
-func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (*domain.AstroProfile, error) {
+func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (_ *domain.AstroProfile, retErr error) {
 	tracer := otel.Tracer("db-astro-profile-repo")
 	repoctx, repoSpan := tracer.Start(ctx, "astro-profile.ReceivingByHas")
 	defer repoSpan.End()
@@ -81,7 +81,12 @@ func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (
 		repoSpan.RecordError(err)
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("close rows: %w", closeErr)
+			repoSpan.RecordError(retErr)
+		}
+	}()
 
 	var p *domain.AstroProfile
 	var encryptedDob []byte

--- a/internal/repositories/db_astro_profile_repo.go
+++ b/internal/repositories/db_astro_profile_repo.go
@@ -1,0 +1,103 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"astroapi/internal/crypto"
+	"astroapi/internal/repositories/domain"
+)
+
+type dbAstroProfileRepo struct {
+	db  *sql.DB
+	key []byte
+}
+
+func NewDbAstroProfileRepo(db *sql.DB, encryptionKey []byte) *dbAstroProfileRepo {
+	return &dbAstroProfileRepo{
+		db:  db,
+		key: encryptionKey,
+	}
+}
+
+func (r *dbAstroProfileRepo) Save(ctx context.Context, profile domain.AstroProfile) error {
+	tracer := otel.Tracer("db-astro-profile-repo")
+	repoctx, repoSpan := tracer.Start(ctx, "astro-profile.Save")
+	defer repoSpan.End()
+
+	encryptedDob, err := crypto.Encrypt(profile.DOB, r.key)
+	if err != nil {
+		err = fmt.Errorf("data encryption failed: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
+
+	now := time.Now()
+	query := `INSERT INTO astro_profile (id, user_id, profile_hash, encrypted_dob, consent_given, created_at, updated_at)
+              VALUES ($1, $2, $3, $4, $5, $6, $7)
+              ON CONFLICT (user_id) DO UPDATE SET
+			  profile_hash = EXCLUDED.profile_hash,
+              encrypted_dob = EXCLUDED.encrypted_dob,
+              updated_at = EXCLUDED.updated_at;`
+	_, err = r.db.ExecContext(repoctx, query, profile.ID, profile.UserID, profile.ProfileHash, encryptedDob, profile.ConsentGiven, now, now)
+	if err != nil {
+		err := fmt.Errorf("error adding data to the astro_profile table: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (*domain.AstroProfile, error) {
+	tracer := otel.Tracer("db-astro-profile-repo")
+	repoctx, repoSpan := tracer.Start(ctx, "astro-profile.ReceivingByHas")
+	defer repoSpan.End()
+
+	if hash == "" {
+		err := errors.New("profile hash must not be empty")
+		repoSpan.RecordError(err)
+		return nil, err
+	}
+	query := `SELECT id, user_id, profile_hash, encrypted_dob, consent_given 
+	          FROM astro_profile 
+			  WHERE profile_hash = $1`
+	rows, err := r.db.QueryContext(repoctx, query, hash)
+	if err != nil {
+		err := fmt.Errorf("error creating request: %w", err)
+		repoSpan.RecordError(err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var p *domain.AstroProfile
+	var encryptedDob []byte
+	if rows.Next() {
+		p = &domain.AstroProfile{}
+		err := rows.Scan(&p.ID, &p.UserID, &p.ProfileHash, &encryptedDob, &p.ConsentGiven)
+		if err != nil {
+			err := fmt.Errorf("data scanning error: %w", err)
+			repoSpan.RecordError(err)
+			return nil, err
+		}
+		p.DOB, err = crypto.Decrypt(encryptedDob, r.key)
+		if err != nil {
+			err := fmt.Errorf("data decryption error: %w", err)
+			repoSpan.RecordError(err)
+			return nil, err
+		}
+
+	}
+	if err := rows.Err(); err != nil {
+		err := fmt.Errorf("error while iterating over rows: %w", err)
+		repoSpan.RecordError(err)
+		return nil, err
+	}
+
+	return p, nil
+}

--- a/internal/repositories/db_astro_profile_repo.go
+++ b/internal/repositories/db_astro_profile_repo.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -37,14 +38,21 @@ func (r *dbAstroProfileRepo) Save(ctx context.Context, profile domain.AstroProfi
 		return err
 	}
 
+	profileDataJSON, err := json.Marshal(profile.ProfileData)
+	if err != nil {
+		err = fmt.Errorf("failed to marshal profile data: %w", err)
+		repoSpan.RecordError(err)
+		return err
+	}
+
 	now := time.Now()
-	query := `INSERT INTO astro_profile (id, user_id, profile_hash, encrypted_dob, consent_given, created_at, updated_at)
+	query := `INSERT INTO astro_profiles (id, user_id, profile_hash, dob_encrypted, consent_given, profile_data, created_at)
               VALUES ($1, $2, $3, $4, $5, $6, $7)
-              ON CONFLICT (user_id) DO UPDATE SET
-			  profile_hash = EXCLUDED.profile_hash,
-              encrypted_dob = EXCLUDED.encrypted_dob,
-              updated_at = EXCLUDED.updated_at;`
-	_, err = r.db.ExecContext(repoctx, query, profile.ID, profile.UserID, profile.ProfileHash, encryptedDob, profile.ConsentGiven, now, now)
+              ON CONFLICT (user_id, profile_hash) DO UPDATE SET
+              dob_encrypted = EXCLUDED.dob_encrypted,
+              consent_given = EXCLUDED.consent_given,
+              profile_data = EXCLUDED.profile_data;`
+	_, err = r.db.ExecContext(repoctx, query, profile.ID, profile.UserID, profile.ProfileHash, encryptedDob, profile.ConsentGiven, profileDataJSON, now)
 	if err != nil {
 		err := fmt.Errorf("error adding data to the astro_profile table: %w", err)
 		repoSpan.RecordError(err)
@@ -64,8 +72,8 @@ func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (
 		repoSpan.RecordError(err)
 		return nil, err
 	}
-	query := `SELECT id, user_id, profile_hash, encrypted_dob, consent_given 
-	          FROM astro_profile 
+	query := `SELECT id, user_id, profile_hash, dob_encrypted, consent_given, profile_data
+	          FROM astro_profiles
 			  WHERE profile_hash = $1`
 	rows, err := r.db.QueryContext(repoctx, query, hash)
 	if err != nil {
@@ -79,7 +87,8 @@ func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (
 	var encryptedDob []byte
 	if rows.Next() {
 		p = &domain.AstroProfile{}
-		err := rows.Scan(&p.ID, &p.UserID, &p.ProfileHash, &encryptedDob, &p.ConsentGiven)
+		var profileDataJSON []byte
+		err := rows.Scan(&p.ID, &p.UserID, &p.ProfileHash, &encryptedDob, &p.ConsentGiven, &profileDataJSON)
 		if err != nil {
 			err := fmt.Errorf("data scanning error: %w", err)
 			repoSpan.RecordError(err)
@@ -91,7 +100,11 @@ func (r *dbAstroProfileRepo) ReceivingByHash(ctx context.Context, hash string) (
 			repoSpan.RecordError(err)
 			return nil, err
 		}
-
+		if err = json.Unmarshal(profileDataJSON, &p.ProfileData); err != nil {
+			err = fmt.Errorf("failed to unmarshal profile data: %w", err)
+			repoSpan.RecordError(err)
+			return nil, err
+		}
 	}
 	if err := rows.Err(); err != nil {
 		err := fmt.Errorf("error while iterating over rows: %w", err)

--- a/internal/repositories/domain/domain.go
+++ b/internal/repositories/domain/domain.go
@@ -12,4 +12,10 @@ type AstroProfile struct {
 	ProfileHash  string
 	DOB          string
 	ConsentGiven bool
+	ProfileData  ProfileData
+}
+
+type ProfileData struct {
+	SunSing   string `json:"sun_sign"`
+	VenusSing string `json:"venus_sing"`
 }

--- a/internal/repositories/domain/domain.go
+++ b/internal/repositories/domain/domain.go
@@ -5,3 +5,11 @@ type PersonalData struct {
 	DOB          string
 	ConsentGiven bool
 }
+
+type AstroProfile struct {
+	ID           string
+	UserID       string
+	ProfileHash  string
+	DOB          string
+	ConsentGiven bool
+}

--- a/internal/usecases/astro_profile.go
+++ b/internal/usecases/astro_profile.go
@@ -1,0 +1,50 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+
+	"astroapi/internal/repositories"
+	"astroapi/internal/repositories/domain"
+)
+
+var ErrNotFound = errors.New("item not found")
+
+type ProcessAstroProfileUseCase struct {
+	dbRepo    repositories.AstroProfileRepository
+	cacheRepo repositories.AstroProfileRepository
+}
+
+func NewProcessAstroProfileUseCase(
+	dbRepo repositories.AstroProfileRepository,
+	cacheRepo repositories.AstroProfileRepository,
+) *ProcessAstroProfileUseCase {
+	return &ProcessAstroProfileUseCase{
+		dbRepo:    dbRepo,
+		cacheRepo: cacheRepo,
+	}
+}
+
+func (uc *ProcessAstroProfileUseCase) ExecuteSave(ctx context.Context, profile domain.AstroProfile) error {
+	if profile.ConsentGiven {
+		return uc.dbRepo.Save(ctx, profile)
+	}
+	return uc.cacheRepo.Save(ctx, profile)
+}
+
+func (uc *ProcessAstroProfileUseCase) ExecuteReceivingByHash(ctx context.Context, hash string) (*domain.AstroProfile, error) {
+	profile, err := uc.cacheRepo.ReceivingByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	if profile == nil {
+		profile, err = uc.dbRepo.ReceivingByHash(ctx, hash)
+		if err != nil {
+			return nil, err
+		}
+		if profile == nil {
+			return nil, ErrNotFound
+		}
+	}
+	return profile, nil
+}

--- a/internal/usecases/astro_profile_test.go
+++ b/internal/usecases/astro_profile_test.go
@@ -1,0 +1,175 @@
+package usecases
+
+import (
+	"astroapi/internal/repositories"
+	"astroapi/internal/repositories/domain"
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func setupTestDbProfile(t *testing.T, ctx context.Context) *sql.DB {
+	t.Helper()
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:15",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "test",
+			"POSTGRES_PASSWORD": "test",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForListeningPort("5432/tcp").
+			WithStartupTimeout(30 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		container.Terminate(ctx)
+	})
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	port, err := container.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+
+	dsn := fmt.Sprintf(
+		"postgres://test:test@%s:%s/testdb?sslmode=disable",
+		host,
+		port.Port(),
+	)
+
+	var db *sql.DB
+
+	require.Eventually(t, func() bool {
+		db, err = sql.Open("postgres", dsn)
+		if err != nil {
+			return false
+		}
+		return db.Ping() == nil
+	}, 10*time.Second, 500*time.Millisecond)
+
+	_, err = db.Exec(`
+	CREATE TABLE astro_profiles (
+	id UUID PRIMARY KEY,
+	user_id VARCHAR(255) NOT NULL,
+	profile_hash VARCHAR(64) NOT NULL,
+	dob_encrypted BYTEA,
+	consent_given BOOLEAN DEFAULT false,
+	profile_data JSONB NOT NULL,
+	created_at TIMESTAMPTZ DEFAULT NOW(),
+	UNIQUE(user_id, profile_hash)
+	)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+// startMemcached запускает контейнер и возвращает адрес "host:port".
+func startMemcached(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "memcached:1.6-alpine",
+			ExposedPorts: []string{"11211/tcp"},
+			WaitingFor:   wait.ForListeningPort("11211/tcp"),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "11211/tcp")
+	require.NoError(t, err)
+
+	return fmt.Sprintf("%s:%s", host, port.Port())
+}
+
+// stubDBRepo используется в тестах кеша, где БД не нужна.
+type stubDBRepo struct{}
+
+func (s *stubDBRepo) Save(_ context.Context, _ domain.AstroProfile) error { return nil }
+func (s *stubDBRepo) ReceivingByHash(_ context.Context, _ string) (*domain.AstroProfile, error) {
+	return nil, nil
+}
+
+// TestAstroProfileUseCaseBD проверяет сохранение и получение через БД.
+func TestAstroProfileUseCaseDB(t *testing.T) {
+	ctx := context.Background()
+
+	db := setupTestDbProfile(t, ctx)
+	defer db.Close()
+
+	dbRepo := repositories.NewDbAstroProfileRepo(
+		db,
+		[]byte("12345678901234567890123456789012"),
+	)
+
+	addr := startMemcached(t)
+	cacheRepo := repositories.NewCacheAstroProfileRepo([]string{addr}, 5*time.Minute)
+
+	uc := NewProcessAstroProfileUseCase(dbRepo, cacheRepo)
+
+	profile := domain.AstroProfile{
+		ID:          "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+		UserID:      "user-123",
+		ProfileHash: "hash-bd-test",
+		DOB:         "01-01-1999",
+		ProfileData: domain.ProfileData{
+			SunSing:   "sun-sing",
+			VenusSing: "venus-sing",
+		},
+		ConsentGiven: true,
+	}
+
+	err := uc.ExecuteSave(ctx, profile)
+	require.NoError(t, err)
+
+	got, err := uc.ExecuteReceivingByHash(ctx, profile.ProfileHash)
+	require.NoError(t, err)
+	require.Equal(t, &profile, got)
+}
+
+// TestAstroProfileUseCaseCache проверяет сохранение и получение через кеш (без согласия).
+func TestAstroProfileUseCaseCache(t *testing.T) {
+	ctx := context.Background()
+
+	addr := startMemcached(t)
+	cacheRepo := repositories.NewCacheAstroProfileRepo([]string{addr}, 5*time.Minute)
+
+	uc := NewProcessAstroProfileUseCase(&stubDBRepo{}, cacheRepo)
+
+	profile := domain.AstroProfile{
+		ID:          "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+		UserID:      "user-456",
+		ProfileHash: "hash-cache-test",
+		DOB:         "15-06-1990",
+		ProfileData: domain.ProfileData{
+			SunSing:   "sun-sing",
+			VenusSing: "venus-sing",
+		},
+		ConsentGiven: false,
+	}
+
+	err := uc.ExecuteSave(ctx, profile)
+	require.NoError(t, err)
+
+	got, err := uc.ExecuteReceivingByHash(ctx, profile.ProfileHash)
+	require.NoError(t, err)
+	require.Equal(t, &profile, got)
+}

--- a/migrations/20260603043610_astro_profiles_table.sql
+++ b/migrations/20260603043610_astro_profiles_table.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+CREATE TABLE astro_profiles (
+  id UUID PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL, -- внешний ID из бота + у нас он же в табл users
+  profile_hash VARCHAR(64) NOT NULL, -- SHA256(dob+user_id) для дедупликации (либо другой способ)
+  dob_encrypted BYTEA, -- шифруется только если consent=true
+  consent_given BOOLEAN DEFAULT false,
+  profile_data JSONB NOT NULL, -- {sun_sign, venus_sign, ...}
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, profile_hash)
+);
+
+CREATE INDEX idx_astro_profiles_hash ON astro_profiles(user_id, profile_hash);;
+
+-- +goose Down
+DROP TABLE IF EXISTS astro_profiles;


### PR DESCRIPTION
1. Добавлена таблица astro_profiles;
2. Реализован usecase astro profile
    Логика сохранения профиля:
    - consent_given = true → данные сохраняются в БД;
    - consent_given = false → данные обрабатываются только в памяти (in-memory), в БД не пишутся.
    Логика получения профиля по profile has:
    - Сначала выполняется поиск в кэше (in‑memory).
    - Если профиль в кэше найден – он сразу возвращается.
    - Если в кэше отсутствует – поиск продолжается в БД.
    - При нахождении в БД профиль возвращается.
    - Если профиль не обнаружен ни в кэше, ни в БД – возвращается ErrNotFound.
3. Реализованы тесты (успешное сохранение и получение профиля в БД/кеше)


Примечание:
usecase astro profile не добавлен в хендлер.
Логика хедндлера profile сейчас:
Принимаем персональные данные → Сохраняем данные в зависимости от consent_given в бд/кеш → публикует в nats → возвращаем 202 и reques_id
Необходимо создать отдельный эдпоинт для расчета профиля или веб-сокет?

bradfitz/gomemcache не поддерживает context  в своих методах
в методах CashAstroProfileRepo контекст принимается, используется только для трейсинга. В дальнейшем можно заменить библиотеку. 