### PR TITLE
fix/refactor-20260630

### DIFF
--- a/internal/repositories/user_repo_test.go
+++ b/internal/repositories/user_repo_test.go
@@ -16,25 +16,22 @@ func setupUserRepoMock(t *testing.T) (sqlmock.Sqlmock, UserRepository, func()) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 
-    cleanup := func() {
-	    mock.ExpectClose()
-	    require.NoError(t, db.Close())
-	    require.NoError(t, mock.ExpectationsWereMet())
-    }
+	cleanup := func() {
+		mock.ExpectClose()
+		require.NoError(t, db.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	}
 
 	return mock, NewUserRepository(db), cleanup
 }
 
 func expectRelatedUserDeletes(mock sqlmock.Sqlmock, userID string) {
-	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromUserConsents)).
+	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromRequestsLog)).
 		WithArgs(userID).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromGenerationResults)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromAstroProfiles)).
 		WithArgs(userID).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromFeedback)).
-		WithArgs(userID).
-		WillReturnResult(sqlmock.NewResult(0, 0))
+		WillReturnResult(sqlmock.NewResult(0, 1))
 }
 
 // успешное удаление
@@ -73,21 +70,15 @@ func TestDeleteUser_NotFound(t *testing.T) {
 	require.False(t, found)
 }
 
-// rollback при ошибке удаления связанных данных
+// rollback при ошибке удаления requests_log
 func TestDeleteUser_RollbackOnError(t *testing.T) {
 	mock, repo, cleanup := setupUserRepoMock(t)
 	defer cleanup()
 	userID := "user-123"
-	expectedErr := errors.New("delete feedback failed")
+	expectedErr := errors.New("delete requests_log failed")
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromUserConsents)).
-		WithArgs(userID).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromGenerationResults)).
-		WithArgs(userID).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromFeedback)).
+	mock.ExpectExec(regexp.QuoteMeta(queryDeleteFromRequestsLog)).
 		WithArgs(userID).
 		WillReturnError(expectedErr)
 	mock.ExpectRollback()

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -7,9 +7,8 @@ import (
 )
 
 const queryDeleteFromUsers = `DELETE FROM users WHERE user_id = $1`
-const queryDeleteFromUserConsents = `DELETE FROM user_consents WHERE user_id = $1`
-const queryDeleteFromGenerationResults = `DELETE FROM generation_results WHERE user_id = $1`
-const queryDeleteFromFeedback = `DELETE FROM feedback WHERE user_id = $1`
+const queryDeleteFromRequestsLog = `DELETE FROM requests_log WHERE user_id = $1`
+const queryDeleteFromAstroProfiles = `DELETE FROM astro_profiles WHERE user_id = $1`
 
 type UserRepository interface {
 	DeleteUsers(ctx context.Context, userID string) (found bool, err error)
@@ -29,7 +28,7 @@ func (t *userRepo) DeleteUsers(ctx context.Context, userID string) (bool, error)
 		return false, err
 	}
 
-	deleteQueries := []string{queryDeleteFromUserConsents, queryDeleteFromGenerationResults, queryDeleteFromFeedback}
+	deleteQueries := []string{queryDeleteFromRequestsLog, queryDeleteFromAstroProfiles}
 	for _, query := range deleteQueries {
 		if _, err := tx.ExecContext(ctx, query, userID); err != nil {
 			_ = tx.Rollback()

--- a/migrations/20260413131319_table_products.sql
+++ b/migrations/20260413131319_table_products.sql
@@ -40,8 +40,6 @@ ALTER TABLE products DROP CONSTRAINT IF EXISTS chk_ext_product_id;
 ALTER TABLE products DROP CONSTRAINT IF EXISTS chk_title;
 ALTER TABLE products DROP CONSTRAINT IF EXISTS chk_price;
 ALTER TABLE products DROP CONSTRAINT IF EXISTS chk_url_is_http_s;
-ALTER TABLE products DROP CONSTRAINT IF EXISTS chk_images_urls;
-
 DROP FUNCTION IF EXISTS update_updated_at_column();
 
 DROP INDEX IF EXISTS  idx_products_tags;

--- a/migrations/20260415_create_recommendations_table.sql
+++ b/migrations/20260415_create_recommendations_table.sql
@@ -1,13 +1,13 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS recommendations (
-                                               id UUID PRIMARY KEY,
-                                               user_id UUID NOT NULL,
-                                               scenario VARCHAR(50) NOT NULL,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id VARCHAR(255) NOT NULL,
+    scenario VARCHAR(50) NOT NULL,
     status VARCHAR(20) NOT NULL DEFAULT 'processing',
     result_text TEXT,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-                             );
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 -- +goose StatementEnd
 
 -- +goose Down

--- a/migrations/20260511120000_fix_timestamps_and_constraints.sql
+++ b/migrations/20260511120000_fix_timestamps_and_constraints.sql
@@ -33,10 +33,6 @@ ALTER TABLE requests_log
     DROP CONSTRAINT IF EXISTS chk_requests_log_status,
     DROP CONSTRAINT IF EXISTS chk_requests_log_scenario;
 
-ALTER TABLE products
-    ALTER COLUMN created_at TYPE TIMESTAMP USING created_at AT TIME ZONE 'UTC',
-    ALTER COLUMN updated_at TYPE TIMESTAMP USING updated_at AT TIME ZONE 'UTC';
-
 ALTER TABLE astro_rules
     ALTER COLUMN created_at TYPE TIMESTAMP USING created_at AT TIME ZONE 'UTC',
     ALTER COLUMN updated_at TYPE TIMESTAMP USING updated_at AT TIME ZONE 'UTC';

--- a/migrations/20260514202600_create_table_astro_profiles_temp.sql
+++ b/migrations/20260514202600_create_table_astro_profiles_temp.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 CREATE TABLE astro_profiles_temp (
     id UUID PRIMARY KEY,
-    user_id UUID NOT NULL UNIQUE,
+    user_id VARCHAR(255) NOT NULL UNIQUE,
     profile JSONB NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/migrations/20260603043610_astro_profiles_table.sql
+++ b/migrations/20260603043610_astro_profiles_table.sql
@@ -1,16 +1,16 @@
 -- +goose Up
 CREATE TABLE astro_profiles (
-  id UUID PRIMARY KEY,
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id VARCHAR(255) NOT NULL, -- внешний ID из бота + у нас он же в табл users
   profile_hash VARCHAR(64) NOT NULL, -- SHA256(dob+user_id) для дедупликации (либо другой способ)
   dob_encrypted BYTEA, -- шифруется только если consent=true
-  consent_given BOOLEAN DEFAULT false,
+  consent_given BOOLEAN NOT NULL DEFAULT false,
   profile_data JSONB NOT NULL, -- {sun_sign, venus_sign, ...}
   created_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(user_id, profile_hash)
 );
 
-CREATE INDEX idx_astro_profiles_hash ON astro_profiles(user_id, profile_hash);;
+CREATE INDEX idx_astro_profiles_hash ON astro_profiles(user_id, profile_hash);
 
 -- +goose Down
 DROP TABLE IF EXISTS astro_profiles;


### PR DESCRIPTION
Исправлено транзакицонное удаление данных клиента. Работает согласно текущей логике. 
Поправлены файлы миграции:
- 20260514202600_create_table_astro_profiles_temp.sql  две ошибки
 user_id UUID NOT NULL UNIQUE — но финальная таблица astro_profiles (миграция 20260603) использует user_id  VARCHAR(255). Тип несовместим с реальной схемой.
 Таблица astro_profiles_temp нигде не дропается в последующих миграциях — висит мусором в БД навсегда.
- 20260415_create_recommendations_table.sql несовместимый тип user_id
 Тип UUID не совпадает с VARCHAR(255) из таблицы users. JOIN или сравнение между ними упадёт. Должно  быть VARCHAR(255).
- 20260603043610_astro_profiles_table.sql двойная `;` (синтаксическая ошибка)
- 20260511120000_fix_timestamps_and_constraints.sql Down секция сломана
- 20260413131319_table_products.sql — Down удаляет несуществующий constraint
- 20260603043610_astro_profiles_table.sql — id без дефолта, consent_given без NOT NULL
